### PR TITLE
Use search endpoint for random assets & cache optimizations

### DIFF
--- a/ImmichFrame.Core/ImmichFrame.Core.csproj
+++ b/ImmichFrame.Core/ImmichFrame.Core.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <OpenApiReference Include="OpenAPIs\immich-openapi-specs.json" CodeGenerator="NSwagCSharp" Namespace="ImmichFrame.Core.Api" ClassName="ImmichApi">
+    <OpenApiReference Include="OpenAPIs\immich-openapi-specs.json" CodeGenerator="NSwagCSharp" Namespace="ImmichFrame.Core.Api" ClassName="ImmichApi" Options="/GenerateOptionalPropertiesAsNullable:true">
       <SourceUri>https://raw.githubusercontent.com/immich-app/immich/main/open-api/immich-openapi-specs.json</SourceUri>
     </OpenApiReference>
   </ItemGroup>

--- a/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
@@ -227,9 +227,26 @@ namespace ImmichFrame.Core.Logic
                 {
                     try
                     {
-                        var personInfo = await immichApi.GetPersonAssetsAsync(personId);
+                        int page = 1;
+                        int batchSize = 1000;
+                        int total = 0;
+                        do
+                        {
+                            var metadataBody = new MetadataSearchDto
+                            {
+                                Page = page,
+                                Size = batchSize,
+                                PersonIds = new []{ personId },
+                                Type = AssetTypeEnum.IMAGE
+                            };
+                            var personInfo = await immichApi.SearchMetadataAsync(metadataBody);
 
-                        allAssets.AddRange(personInfo);
+                            total = personInfo.Assets.Total;
+
+                            allAssets.AddRange(personInfo.Assets.Items);
+                            page++;
+                        }
+                        while ( total == batchSize);
                     }
                     catch (ApiException ex)
                     {

--- a/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
@@ -161,7 +161,7 @@ namespace ImmichFrame.Core.Logic
                 foreach (var lane in memoryLane)
                 {
                     var assets = lane.Assets.ToList();
-                    assets.ForEach(asset => asset.ImageDesc =  $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
+                    assets.ForEach(asset => asset.ImageDesc = $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
 
                     allAssets.AddRange(assets);
                 }
@@ -263,7 +263,14 @@ namespace ImmichFrame.Core.Logic
                 var immichApi = new ImmichApi(_settings.ImmichServerUrl, client);
                 try
                 {
-                    var randomAssets = await immichApi.GetRandomAsync(null);
+                    var searchBody = new RandomSearchDto
+                    {
+                        Size = 1,
+                        Page = 1
+                    };
+                    var searchResponse = await immichApi.SearchRandomAsync(searchBody);
+
+                    var randomAssets = searchResponse.Assets.Items;
 
                     if (randomAssets.Any())
                     {

--- a/ImmichFrame.Core/OpenAPIs/immich-openapi-specs.json
+++ b/ImmichFrame.Core/OpenAPIs/immich-openapi-specs.json
@@ -1646,6 +1646,8 @@
     },
     "/assets/random": {
       "get": {
+        "deprecated": true,
+        "description": "This property was deprecated in v1.116.0",
         "operationId": "getRandom",
         "parameters": [
           {
@@ -1685,8 +1687,12 @@
           }
         ],
         "tags": [
-          "Assets"
-        ]
+          "Assets",
+          "Deprecated"
+        ],
+        "x-immich-lifecycle": {
+          "deprecatedAt": "v1.116.0"
+        }
       }
     },
     "/assets/statistics": {
@@ -2561,6 +2567,39 @@
         "tags": [
           "Jobs"
         ]
+      },
+      "post": {
+        "operationId": "createJob",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JobCreateDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Jobs"
+        ]
       }
     },
     "/jobs/{id}": {
@@ -3106,55 +3145,6 @@
                     "$ref": "#/components/schemas/MapReverseGeocodeResponseDto"
                   },
                   "type": "array"
-                }
-              }
-            },
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "bearer": []
-          },
-          {
-            "cookie": []
-          },
-          {
-            "api_key": []
-          }
-        ],
-        "tags": [
-          "Map"
-        ]
-      }
-    },
-    "/map/style.json": {
-      "get": {
-        "operationId": "getMapStyle",
-        "parameters": [
-          {
-            "name": "key",
-            "required": false,
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "theme",
-            "required": true,
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/MapTheme"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
                 }
               }
             },
@@ -4644,6 +4634,48 @@
         ]
       }
     },
+    "/search/random": {
+      "post": {
+        "operationId": "searchRandom",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RandomSearchDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponseDto"
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          },
+          {
+            "cookie": []
+          },
+          {
+            "api_key": []
+          }
+        ],
+        "tags": [
+          "Search"
+        ]
+      }
+    },
     "/search/smart": {
       "post": {
         "operationId": "searchSmart",
@@ -5275,8 +5307,8 @@
             "name": "password",
             "required": false,
             "in": "query",
-            "example": "password",
             "schema": {
+              "example": "password",
               "type": "string"
             }
           },
@@ -6806,7 +6838,14 @@
         "operationId": "emptyTrash",
         "parameters": [],
         "responses": {
-          "204": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrashResponseDto"
+                }
+              }
+            },
             "description": ""
           }
         },
@@ -6831,7 +6870,14 @@
         "operationId": "restoreTrash",
         "parameters": [],
         "responses": {
-          "204": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrashResponseDto"
+                }
+              }
+            },
             "description": ""
           }
         },
@@ -6866,7 +6912,14 @@
           "required": true
         },
         "responses": {
-          "204": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrashResponseDto"
+                }
+              }
+            },
             "description": ""
           }
         },
@@ -7394,7 +7447,7 @@
   "info": {
     "title": "Immich",
     "description": "Immich API",
-    "version": "1.113.0",
+    "version": "1.115.0",
     "contact": {}
   },
   "tags": [],
@@ -7928,6 +7981,9 @@
           "id": {
             "type": "string"
           },
+          "isTrashed": {
+            "type": "boolean"
+          },
           "reason": {
             "enum": [
               "duplicate",
@@ -8018,6 +8074,9 @@
               }
             ],
             "nullable": true
+          },
+          "sourceType": {
+            "$ref": "#/components/schemas/SourceType"
           }
         },
         "required": [
@@ -8086,6 +8145,9 @@
           },
           "imageWidth": {
             "type": "integer"
+          },
+          "sourceType": {
+            "$ref": "#/components/schemas/SourceType"
           }
         },
         "required": [
@@ -8737,6 +8799,10 @@
       },
       "CreateProfileImageResponseDto": {
         "properties": {
+          "profileChangedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "profileImagePath": {
             "type": "string"
           },
@@ -8745,6 +8811,7 @@
           }
         },
         "required": [
+          "profileChangedAt",
           "profileImagePath",
           "userId"
         ],
@@ -9052,7 +9119,7 @@
           "maxDistance": {
             "format": "double",
             "maximum": 2,
-            "minimum": 0,
+            "minimum": 0.1,
             "type": "number"
           },
           "minFaces": {
@@ -9062,7 +9129,7 @@
           "minScore": {
             "format": "double",
             "maximum": 1,
-            "minimum": 0,
+            "minimum": 0.1,
             "type": "number"
           },
           "modelName": {
@@ -9257,6 +9324,17 @@
           "failed",
           "paused",
           "waiting"
+        ],
+        "type": "object"
+      },
+      "JobCreateDto": {
+        "properties": {
+          "name": {
+            "$ref": "#/components/schemas/ManualJobName"
+          }
+        },
+        "required": [
+          "name"
         ],
         "type": "object"
       },
@@ -9502,6 +9580,14 @@
         ],
         "type": "object"
       },
+      "ManualJobName": {
+        "enum": [
+          "person-cleanup",
+          "tag-cleanup",
+          "user-cleanup"
+        ],
+        "type": "string"
+      },
       "MapMarkerResponseDto": {
         "properties": {
           "city": {
@@ -9559,13 +9645,6 @@
           "state"
         ],
         "type": "object"
-      },
-      "MapTheme": {
-        "enum": [
-          "light",
-          "dark"
-        ],
-        "type": "string"
       },
       "MemoriesResponse": {
         "properties": {
@@ -9954,6 +10033,10 @@
           "name": {
             "type": "string"
           },
+          "profileChangedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "profileImagePath": {
             "type": "string"
           }
@@ -9963,6 +10046,7 @@
           "email",
           "id",
           "name",
+          "profileChangedAt",
           "profileImagePath"
         ],
         "type": "object"
@@ -10362,6 +10446,130 @@
         ],
         "type": "object"
       },
+      "RandomSearchDto": {
+        "properties": {
+          "city": {
+            "nullable": true,
+            "type": "string"
+          },
+          "country": {
+            "nullable": true,
+            "type": "string"
+          },
+          "createdAfter": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "createdBefore": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deviceId": {
+            "type": "string"
+          },
+          "isArchived": {
+            "type": "boolean"
+          },
+          "isEncoded": {
+            "type": "boolean"
+          },
+          "isFavorite": {
+            "type": "boolean"
+          },
+          "isMotion": {
+            "type": "boolean"
+          },
+          "isNotInAlbum": {
+            "type": "boolean"
+          },
+          "isOffline": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "lensModel": {
+            "nullable": true,
+            "type": "string"
+          },
+          "libraryId": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "make": {
+            "type": "string"
+          },
+          "model": {
+            "nullable": true,
+            "type": "string"
+          },
+          "page": {
+            "minimum": 1,
+            "type": "number"
+          },
+          "personIds": {
+            "items": {
+              "format": "uuid",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "size": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "number"
+          },
+          "state": {
+            "nullable": true,
+            "type": "string"
+          },
+          "takenAfter": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "takenBefore": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "trashedAfter": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "trashedBefore": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AssetTypeEnum"
+          },
+          "updatedAfter": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "updatedBefore": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "withArchived": {
+            "default": false,
+            "type": "boolean"
+          },
+          "withDeleted": {
+            "type": "boolean"
+          },
+          "withExif": {
+            "type": "boolean"
+          },
+          "withPeople": {
+            "type": "boolean"
+          },
+          "withStacked": {
+            "type": "boolean"
+          }
+        },
+        "type": "object"
+      },
       "RatingsResponse": {
         "properties": {
           "enabled": {
@@ -10653,6 +10861,12 @@
           "loginPageMessage": {
             "type": "string"
           },
+          "mapDarkStyleUrl": {
+            "type": "string"
+          },
+          "mapLightStyleUrl": {
+            "type": "string"
+          },
           "oauthButtonText": {
             "type": "string"
           },
@@ -10668,6 +10882,8 @@
           "isInitialized",
           "isOnboarded",
           "loginPageMessage",
+          "mapDarkStyleUrl",
+          "mapLightStyleUrl",
           "oauthButtonText",
           "trashDays",
           "userDeleteDelay"
@@ -10686,6 +10902,9 @@
             "type": "boolean"
           },
           "facialRecognition": {
+            "type": "boolean"
+          },
+          "importFaces": {
             "type": "boolean"
           },
           "map": {
@@ -10721,6 +10940,7 @@
           "duplicateDetection",
           "email",
           "facialRecognition",
+          "importFaces",
           "map",
           "oauth",
           "oauthAutoLaunch",
@@ -11229,6 +11449,13 @@
         ],
         "type": "object"
       },
+      "SourceType": {
+        "enum": [
+          "machine-learning",
+          "exif"
+        ],
+        "type": "string"
+      },
       "StackCreateDto": {
         "properties": {
           "assetIds": {
@@ -11299,6 +11526,9 @@
           "map": {
             "$ref": "#/components/schemas/SystemConfigMapDto"
           },
+          "metadata": {
+            "$ref": "#/components/schemas/SystemConfigMetadataDto"
+          },
           "newVersionCheck": {
             "$ref": "#/components/schemas/SystemConfigNewVersionCheckDto"
           },
@@ -11338,6 +11568,7 @@
           "logging",
           "machineLearning",
           "map",
+          "metadata",
           "newVersionCheck",
           "notifications",
           "oauth",
@@ -11461,6 +11692,17 @@
           "tonemap",
           "transcode",
           "twoPass"
+        ],
+        "type": "object"
+      },
+      "SystemConfigFacesDto": {
+        "properties": {
+          "import": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "import"
         ],
         "type": "object"
       },
@@ -11653,6 +11895,17 @@
           "darkStyle",
           "enabled",
           "lightStyle"
+        ],
+        "type": "object"
+      },
+      "SystemConfigMetadataDto": {
+        "properties": {
+          "faces": {
+            "$ref": "#/components/schemas/SystemConfigFacesDto"
+          }
+        },
+        "required": [
+          "faces"
         ],
         "type": "object"
       },
@@ -12146,6 +12399,17 @@
         ],
         "type": "string"
       },
+      "TrashResponseDto": {
+        "properties": {
+          "count": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "count"
+        ],
+        "type": "object"
+      },
       "UpdateAlbumDto": {
         "properties": {
           "albumName": {
@@ -12194,6 +12458,11 @@
           },
           "latitude": {
             "type": "number"
+          },
+          "livePhotoVideoId": {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
           },
           "longitude": {
             "type": "number"
@@ -12351,6 +12620,10 @@
           "oauthId": {
             "type": "string"
           },
+          "profileChangedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "profileImagePath": {
             "type": "string"
           },
@@ -12389,6 +12662,7 @@
           "license",
           "name",
           "oauthId",
+          "profileChangedAt",
           "profileImagePath",
           "quotaSizeInBytes",
           "quotaUsageInBytes",
@@ -12550,6 +12824,10 @@
           "name": {
             "type": "string"
           },
+          "profileChangedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
           "profileImagePath": {
             "type": "string"
           }
@@ -12559,6 +12837,7 @@
           "email",
           "id",
           "name",
+          "profileChangedAt",
           "profileImagePath"
         ],
         "type": "object"

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -10,12 +10,12 @@ namespace ImmichFrame.WebApi.Controllers
     public class AssetController : ControllerBase
     {
         private readonly ILogger<AssetController> _logger;
-        private IImmichFrameLogic _logic;
+        private readonly IImmichFrameLogic _logic;
 
-        public AssetController(ILogger<AssetController> logger, IBaseSettings settings)
+        public AssetController(ILogger<AssetController> logger, ImmichFrameLogic logic)
         {
             _logger = logger;
-            _logic = new ImmichFrameLogic(settings);
+            _logic = logic;
         }
 
         [HttpGet(Name = "GetAsset")]

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -1,5 +1,6 @@
 using ImmichFrame.Core.Exceptions;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Logic;
 using ImmichFrame.WebApi.Models;
 using System.Text.Json;
 
@@ -20,14 +21,14 @@ catch (Exception ex)
     throw new SettingsNotValidException($"Problem with parsing the settings: {ex.Message}", ex);
 }
 
-builder.Services.AddSingleton<IBaseSettings>(srv =>
+builder.Services.AddSingleton(srv =>
 {
     var settings = JsonSerializer.Deserialize<Settings>(doc);
 
     if (settings == null)
         throw new FileNotFoundException();
 
-    return settings;
+    return new ImmichFrameLogic(settings);
 });
 
 builder.Services.AddControllers();


### PR DESCRIPTION
> [!WARNING]
This will only work with immich-server version 1.116 or higher

Following things were changed:
- updated Openapi-Specs
- use new random endpoint
- use caching for random endpoint to reduce load on immich api
- use search metadata endpoint instead of deprecated `GetPersonAssets`
- updated generation of immich client