### PR TITLE
Feat: Identify client requests

### DIFF
--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -51,12 +51,12 @@ namespace ImmichFrame.WebApi.Controllers
 
         [HttpGet("RandomImageAndInfo", Name = "GetRandomImageAndInfo")]
         [Produces("application/json")]
-        public async Task<ImageResponse> GetRandomImageAndInfo()
+        public async Task<ImageResponse> GetRandomImageAndInfo(string clientIdentifier = "")
         {
             var randomImage = await _logic.GetNextAsset() ?? throw new AssetNotFoundException("No asset was found");
 
             var image = await _logic.GetImage(new Guid(randomImage.Id));
-            var notification = new ImageRequestedNotification(new Guid(randomImage.Id));
+            var notification = new ImageRequestedNotification(new Guid(randomImage.Id), clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
             string randomImageBase64;

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -39,11 +39,11 @@ namespace ImmichFrame.WebApi.Controllers
         [HttpGet("{id}", Name = "GetImage")]
         [Produces("image/jpeg", "image/webp")]
         [ProducesResponseType(typeof(FileStreamResult), StatusCodes.Status200OK)]
-        public async Task<FileResult> GetImage(Guid id)
+        public async Task<FileResult> GetImage(Guid id, string clientIdentifier = "")
         {
             var image = await _logic.GetImage(id);
 
-            var notification = new ImageRequestedNotification(id);
+            var notification = new ImageRequestedNotification(id, clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
             return File(image.fileStream, image.ContentType, image.fileName); // returns a FileStreamResult

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -31,7 +31,7 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetAsset")]
-        public async Task<List<AssetResponseDto>> GetAsset()
+        public async Task<List<AssetResponseDto>> GetAsset(string clientIdentifier = "")
         {
             return await _logic.GetAssets() ?? throw new AssetNotFoundException("No asset was found");
         }

--- a/ImmichFrame.WebApi/Controllers/CalendarController.cs
+++ b/ImmichFrame.WebApi/Controllers/CalendarController.cs
@@ -18,7 +18,7 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetAppointments")]
-        public async Task<List<IAppointment>> GetAppointments()
+        public async Task<List<IAppointment>> GetAppointments(string clientIdentifier = "")
         {
             return await _logic.GetAppointments();
         }

--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -18,7 +18,7 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetConfig")]
-        public WebClientSettings GetConfig()
+        public WebClientSettings GetConfig(string clientIdentifier = "")
         {
             return (WebClientSettings)_settings;
         }

--- a/ImmichFrame.WebApi/Controllers/WeatherController.cs
+++ b/ImmichFrame.WebApi/Controllers/WeatherController.cs
@@ -19,7 +19,7 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetWeather")]
-        public async Task<IWeather?> GetWeather()
+        public async Task<IWeather?> GetWeather(string clientIdentifier = "")
         {
             return await _logic.GetWeather();
         }

--- a/ImmichFrame.WebApi/Models/ImageRequestedNotification.cs
+++ b/ImmichFrame.WebApi/Models/ImageRequestedNotification.cs
@@ -5,12 +5,14 @@ namespace ImmichFrame.WebApi.Models
     public class ImageRequestedNotification : IWebhookNotification
     {
         public string Name { get; set; }
+        public string ClientIdentifier { get; set; }
         public DateTime DateTime { get; set; }
         public Guid RequestedImageId { get; set; }
 
-        public ImageRequestedNotification(Guid imageId)
+        public ImageRequestedNotification(Guid imageId, string clientIdentifier)
         {
             Name = nameof(ImageRequestedNotification);
+            ClientIdentifier = clientIdentifier;
             DateTime = DateTime.Now;
             RequestedImageId = imageId;
         }

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -10,10 +10,7 @@ builder.Logging.AddConsole();
 
 // Add services to the container.
 
-
 var settingsPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Config", "Settings.json");
-
-Console.WriteLine(settingsPath);
 
 ServerSettings? serverSettings = null;
 WebClientSettings? clientSettings = null;

--- a/immichFrame.Web/src/lib/components/elements/appointments.svelte
+++ b/immichFrame.Web/src/lib/components/elements/appointments.svelte
@@ -3,6 +3,7 @@
 	import { onMount } from 'svelte';
 	import { format, formatDate } from 'date-fns';
 	import { configStore } from '$lib/stores/config.store';
+	import { clientIdentifierStore } from '$lib/stores/identifier.store';
 
 	function formattedDate(time: string) {
 		let date = new Date(time);
@@ -21,7 +22,9 @@
 	});
 
 	async function GetAppointments() {
-		let appointmentRequest = await api.getAppointments();
+		let appointmentRequest = await api.getAppointments({
+			clientIdentifier: $clientIdentifierStore
+		});
 		if (appointmentRequest.status == 200) {
 			appointments = appointmentRequest.data;
 

--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -4,6 +4,7 @@
 	import { format } from 'date-fns';
 	import * as locale from 'date-fns/locale';
 	import { configStore } from '$lib/stores/config.store';
+	import { clientIdentifierStore } from '$lib/stores/identifier.store';
 
 	let time = $state(new Date());
 	let weather: api.IWeather = $state() as api.IWeather;
@@ -35,7 +36,7 @@
 	});
 
 	async function GetWeather() {
-		let weatherRequest = await api.getWeather();
+		let weatherRequest = await api.getWeather({ clientIdentifier: $clientIdentifierStore });
 		if (weatherRequest.status == 200) {
 			weather = weatherRequest.data;
 		}

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -9,6 +9,7 @@
 	import { fade } from 'svelte/transition';
 	import { configStore } from '$lib/stores/config.store';
 	import { Confetti } from 'svelte-confetti';
+	import { clientIdentifierStore } from '$lib/stores/identifier.store';
 
 	interface Props {
 		sourceAssets: AssetResponseDto[];
@@ -75,7 +76,7 @@
 
 	async function loadImage(a: AssetResponseDto) {
 		try {
-			let req = await api.getImage(a.id);
+			let req = await api.getImage(a.id, { clientIdentifier: $clientIdentifierStore });
 
 			if (req.status != 200) {
 				error = true;

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -5,6 +5,7 @@
 		ProgressBarStatus
 	} from '$lib/components/elements/progress-bar.svelte';
 	import { slideshowStore } from '$lib/stores/slideshow.store';
+	import { clientIdentifierStore } from '$lib/stores/identifier.store';
 	import { onDestroy, onMount } from 'svelte';
 	import OverlayControls from '../elements/overlay-controls.svelte';
 	import ImageComponent from '../elements/image-component.svelte';
@@ -13,6 +14,7 @@
 	import Clock from '../elements/clock.svelte';
 	import Appointments from '../elements/appointments.svelte';
 	import LoadingElement from '../elements/LoadingElement.svelte';
+	import { page } from '$app/stores';
 
 	let assetHistory: api.AssetResponseDto[] = [];
 	let assetBacklog: api.AssetResponseDto[] = [];
@@ -30,6 +32,14 @@
 
 	let cursorVisible = $state(true);
 	let timeoutId: number;
+
+	const clientIdentifier = $page.url.searchParams.get('client');
+
+	$clientIdentifierStore;
+
+	if (clientIdentifier && clientIdentifier != $clientIdentifierStore) {
+		clientIdentifierStore.set(clientIdentifier);
+	}
 
 	const hideCursor = () => {
 		cursorVisible = false;

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -6,6 +6,7 @@
  * See https://www.npmjs.com/package/oazapfts
  */
 import * as Oazapfts from "@oazapfts/runtime";
+import * as QS from "@oazapfts/runtime/query";
 export const defaults: Oazapfts.Defaults<Oazapfts.CustomHeaders> = {
     headers: {},
     baseUrl: "/",
@@ -182,43 +183,63 @@ export type IWeather = {
     description?: string | null;
     iconId?: string | null;
 };
-export function getAsset(opts?: Oazapfts.RequestOpts) {
+export function getAsset({ clientIdentifier }: {
+    clientIdentifier?: string;
+} = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
         data: AssetResponseDto[];
-    }>("/api/Asset", {
+    }>(`/api/Asset${QS.query(QS.explode({
+        clientIdentifier
+    }))}`, {
         ...opts
     });
 }
-export function getImage(id: string, opts?: Oazapfts.RequestOpts) {
+export function getImage(id: string, { clientIdentifier }: {
+    clientIdentifier?: string;
+} = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchBlob<{
         status: 200;
         data: Blob;
-    }>(`/api/Asset/${encodeURIComponent(id)}`, {
+    }>(`/api/Asset/${encodeURIComponent(id)}${QS.query(QS.explode({
+        clientIdentifier
+    }))}`, {
         ...opts
     });
 }
-export function getAppointments(opts?: Oazapfts.RequestOpts) {
+export function getAppointments({ clientIdentifier }: {
+    clientIdentifier?: string;
+} = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
         data: IAppointment[];
-    }>("/api/Calendar", {
+    }>(`/api/Calendar${QS.query(QS.explode({
+        clientIdentifier
+    }))}`, {
         ...opts
     });
 }
-export function getConfig(opts?: Oazapfts.RequestOpts) {
+export function getConfig({ clientIdentifier }: {
+    clientIdentifier?: string;
+} = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
         data: WebClientSettings;
-    }>("/api/Config", {
+    }>(`/api/Config${QS.query(QS.explode({
+        clientIdentifier
+    }))}`, {
         ...opts
     });
 }
-export function getWeather(opts?: Oazapfts.RequestOpts) {
+export function getWeather({ clientIdentifier }: {
+    clientIdentifier?: string;
+} = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
         data: IWeather;
-    }>("/api/Weather", {
+    }>(`/api/Weather${QS.query(QS.explode({
+        clientIdentifier
+    }))}`, {
         ...opts
     });
 }

--- a/immichFrame.Web/src/lib/stores/identifier.store.ts
+++ b/immichFrame.Web/src/lib/stores/identifier.store.ts
@@ -1,0 +1,25 @@
+
+import { writable } from 'svelte/store';
+
+function persistStore(key: string, defaultValue: string) {
+    const storedValue = localStorage.getItem(key);
+    const initialValue: string = storedValue ? JSON.parse(storedValue) : defaultValue;
+
+    const store = writable(initialValue);
+
+    store.subscribe((value) => {
+        localStorage.setItem(key, JSON.stringify(value));
+    });
+
+    return store;
+}
+
+function generateGUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        const r = (Math.random() * 16) | 0,
+            v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+}
+
+export const clientIdentifierStore = persistStore('clientIdentifier', generateGUID());

--- a/immichFrame.Web/src/routes/+page.ts
+++ b/immichFrame.Web/src/routes/+page.ts
@@ -1,9 +1,9 @@
 import * as api from '$lib/immichFrameApi';
 import { configStore } from '$lib/stores/config.store.js'
 
-export const load = async ({ fetch }) => {
+export const load = async () => {
 
-  const configRequest = await api.getConfig({ fetch });
+  const configRequest = await api.getConfig({ clientIdentifier: "" });
 
   const config = configRequest.data;
 


### PR DESCRIPTION
Clients are now identified by a random identifier (UUID) that can be overwritten with `?client=MyClient`. This will be persisted and does only need to be called once.

The webhook message will now also show the identifier send by the client. e.g.

```json
{
  "Name": "ImageRequestedNotification",
  "ClientIdentifier": "Frame_Kitchen",
  "DateTime": "2024-12-11T17:40:58.5034185\u002B01:00",
  "RequestedImageId": "eee299ac-b9e0-4249-aff9-d0a970e1572c"
}
```

Closes #230 