### PR TITLE
Add the 'manual' option to the sourceType enum

### DIFF
--- a/ImmichFrame.Core/OpenAPIs/immich-openapi-specs.json
+++ b/ImmichFrame.Core/OpenAPIs/immich-openapi-specs.json
@@ -11455,7 +11455,8 @@
       "SourceType": {
         "enum": [
           "machine-learning",
-          "exif"
+          "exif",
+          "manual"
         ],
         "type": "string"
       },

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -52,7 +52,7 @@ export type UserResponseDto = {
         [key: string]: any | null;
     } | null;
 };
-export type SourceType = 0 | 1;
+export type SourceType = 0 | 1 | 2;
 export type AssetFaceWithoutPersonResponseDto = {
     boundingBoxX1?: number;
     boundingBoxX2?: number;


### PR DESCRIPTION
This fixes the API schema error in #279 by adding the new enum value added in the recent update.
