### PR TITLE
Fix: Height on mobile devices by switching from h-screen to h-dvh

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,17 +5,11 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com?compatibility"></script>
-    <style>
-        #full_section {
-            height: 100vh;
-            height: 100dvh;
-        }
-    </style>
 </head>
 
 <body class="bg-gray-100 overflow-hidden">
     <!-- Full Section with Flexbox to Ensure Everything Fits -->
-    <section id="full_section" class="flex flex-col bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
+    <section class="flex flex-col h-dvh bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
         <!-- Compact Instructions Section -->
         <div class="w-full bg-gray-200 text-gray-800 px-3 py-2 text-center">
             <div class="max-w-3xl mx-auto"> 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,17 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com?compatibility"></script>
+    <style>
+        #full_section {
+            height: 100vh;
+            height: 100dvh;
+        }
+    </style>
 </head>
 
 <body class="bg-gray-100 overflow-hidden">
     <!-- Full Section with Flexbox to Ensure Everything Fits -->
-    <section class="flex flex-col h-dvh bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
+    <section id="full_section" class="flex flex-col bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
         <!-- Compact Instructions Section -->
         <div class="w-full bg-gray-200 text-gray-800 px-3 py-2 text-center">
             <div class="max-w-3xl mx-auto"> 

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
 
 <body class="bg-gray-100 overflow-hidden">
     <!-- Full Section with Flexbox to Ensure Everything Fits -->
-    <section class="flex flex-col h-screen bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
+    <section class="flex flex-col h-dvh bg-gradient-to-b from-gray-200 to-gray-300 text-gray-800">
         <!-- Compact Instructions Section -->
         <div class="w-full bg-gray-200 text-gray-800 px-3 py-2 text-center">
             <div class="max-w-3xl mx-auto"> 

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -100,8 +100,7 @@
 
 {#if hasBday}
 	<div
-		id="bday"
-		class="	z-[1000] top-[-50px] fixed l-0 w-screen flex justify-center overflow-hidden pointer-events-none"
+		class="	z-[1000] top-[-50px] fixed l-0 h-dvh w-screen flex justify-center overflow-hidden pointer-events-none"
 	>
 		<Confetti
 			x={[-5, 5]}
@@ -119,10 +118,10 @@
 	<ErrorElement />
 {:else if loaded}
 	{#key images}
-		<div class="image_container grid absolute w-screen" transition:fade={{ duration: transitionDuration }}>
+		<div class="grid absolute h-dvh w-screen" transition:fade={{ duration: transitionDuration }}>
 			{#if split}
 				<div class="grid grid-cols-2">
-					<div id="image_portrait_1" class="relative grid border-r-2 border-primary">
+					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-dvh">
 						<Image
 							multi={true}
 							image={images[0]}
@@ -132,7 +131,7 @@
 							{showPeopleDesc}
 						/>
 					</div>
-					<div id="image_portrait_2" class="relative grid border-l-2 border-primary">
+					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-dvh">
 						<Image
 							multi={true}
 							image={images[1]}
@@ -144,7 +143,7 @@
 					</div>
 				</div>
 			{:else}
-				<div id="image_default" class="relative grid w-screen">
+				<div id="image_default" class="relative grid h-dvh w-screen">
 					<Image
 						image={images[0]}
 						{showLocation}
@@ -159,18 +158,3 @@
 {:else}
 	<LoadingElement />
 {/if}
-
-<style>
-	#bday {
-		height: 100vh;
-		height: 100dvh;
-	}
-	.image_container {
-		height: 100vh;
-		height: 100dvh;
-	}
-	#image_default, #image_portrait_1, #image_portrait_2 {
-		height: 100vh;
-		height: 100dvh;
-	}
-</style>

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -100,7 +100,8 @@
 
 {#if hasBday}
 	<div
-		class="	z-[1000] top-[-50px] fixed l-0 h-dvh w-screen flex justify-center overflow-hidden pointer-events-none"
+		id="bday"
+		class="	z-[1000] top-[-50px] fixed l-0 w-screen flex justify-center overflow-hidden pointer-events-none"
 	>
 		<Confetti
 			x={[-5, 5]}
@@ -118,10 +119,10 @@
 	<ErrorElement />
 {:else if loaded}
 	{#key images}
-		<div class="grid absolute h-dvh w-screen" transition:fade={{ duration: transitionDuration }}>
+		<div class="image_container grid absolute w-screen" transition:fade={{ duration: transitionDuration }}>
 			{#if split}
 				<div class="grid grid-cols-2">
-					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-dvh">
+					<div id="image_portrait_1" class="relative grid border-r-2 border-primary">
 						<Image
 							multi={true}
 							image={images[0]}
@@ -131,7 +132,7 @@
 							{showPeopleDesc}
 						/>
 					</div>
-					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-dvh">
+					<div id="image_portrait_2" class="relative grid border-l-2 border-primary">
 						<Image
 							multi={true}
 							image={images[1]}
@@ -143,7 +144,7 @@
 					</div>
 				</div>
 			{:else}
-				<div id="image_default" class="relative grid h-dvh w-screen">
+				<div id="image_default" class="relative grid w-screen">
 					<Image
 						image={images[0]}
 						{showLocation}
@@ -158,3 +159,18 @@
 {:else}
 	<LoadingElement />
 {/if}
+
+<style>
+	#bday {
+		height: 100vh;
+		height: 100dvh;
+	}
+	.image_container {
+		height: 100vh;
+		height: 100dvh;
+	}
+	#image_default, #image_portrait_1, #image_portrait_2 {
+		height: 100vh;
+		height: 100dvh;
+	}
+</style>

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -100,7 +100,7 @@
 
 {#if hasBday}
 	<div
-		class="	z-[1000] top-[-50px] fixed l-0 h-screen w-screen flex justify-center overflow-hidden pointer-events-none"
+		class="	z-[1000] top-[-50px] fixed l-0 h-dvh w-screen flex justify-center overflow-hidden pointer-events-none"
 	>
 		<Confetti
 			x={[-5, 5]}
@@ -118,10 +118,10 @@
 	<ErrorElement />
 {:else if loaded}
 	{#key images}
-		<div class="grid absolute h-screen w-screen" transition:fade={{ duration: transitionDuration }}>
+		<div class="grid absolute h-dvh w-screen" transition:fade={{ duration: transitionDuration }}>
 			{#if split}
 				<div class="grid grid-cols-2">
-					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-screen">
+					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-dvh">
 						<Image
 							multi={true}
 							image={images[0]}
@@ -131,7 +131,7 @@
 							{showPeopleDesc}
 						/>
 					</div>
-					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-screen">
+					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-dvh">
 						<Image
 							multi={true}
 							image={images[1]}
@@ -143,7 +143,7 @@
 					</div>
 				</div>
 			{:else}
-				<div id="image_default" class="relative grid h-screen w-screen">
+				<div id="image_default" class="relative grid h-dvh w-screen">
 					<Image
 						image={images[0]}
 						{showLocation}

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -146,7 +146,7 @@
 		style="--interval: {interval + 2}s; --posX: {getCenterX(0)}%; --posY: {getCenterY(0)}%;"
 		class="{multi
 			? 'w-screen'
-			: 'full_height max-w-full'} object-contain {$configStore.imageZoom
+			: 'max-h-screen h-dvh max-w-full'} object-contain {$configStore.imageZoom
 			? zoomEffect()
 				? hasPerson
 					? 'zoom-in-person'
@@ -167,12 +167,6 @@
 />
 
 <style>
-	.immichframe_image img.full_height {
-		max-height: 100vh;
-		height: 100vh;
-		height: 100dvh;
-	}
-
 	.zoom-in {
 		animation: zoom-in var(--interval) ease-out normal;
 	}

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -146,7 +146,7 @@
 		style="--interval: {interval + 2}s; --posX: {getCenterX(0)}%; --posY: {getCenterY(0)}%;"
 		class="{multi
 			? 'w-screen'
-			: 'max-h-screen h-dvh max-w-full'} object-contain {$configStore.imageZoom
+			: 'full_height max-w-full'} object-contain {$configStore.imageZoom
 			? zoomEffect()
 				? hasPerson
 					? 'zoom-in-person'
@@ -167,6 +167,12 @@
 />
 
 <style>
+	.immichframe_image img.full_height {
+		max-height: 100vh;
+		height: 100vh;
+		height: 100dvh;
+	}
+
 	.zoom-in {
 		animation: zoom-in var(--interval) ease-out normal;
 	}

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -146,7 +146,7 @@
 		style="--interval: {interval + 2}s; --posX: {getCenterX(0)}%; --posY: {getCenterY(0)}%;"
 		class="{multi
 			? 'w-screen'
-			: 'max-h-screen h-screen max-w-full'} object-contain {$configStore.imageZoom
+			: 'max-h-screen h-dvh max-w-full'} object-contain {$configStore.imageZoom
 			? zoomEffect()
 				? hasPerson
 					? 'zoom-in-person'

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -204,7 +204,7 @@
 	});
 </script>
 
-<section class="fixed grid h-dvh w-screen bg-black" class:cursor-none={!cursorVisible}>
+<section class="fixed grid w-screen bg-black" class:cursor-none={!cursorVisible}>
 	{#if error}
 		<ErrorElement {authError} message={errorMessage} />
 	{:else if displayingAssets}
@@ -253,3 +253,10 @@
 		<LoadingElement />
 	{/if}
 </section>
+
+<style>
+	section {
+		height: 100vh;
+		height: 100dvh;
+	}
+</style>

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -204,7 +204,7 @@
 	});
 </script>
 
-<section class="fixed grid w-screen bg-black" class:cursor-none={!cursorVisible}>
+<section class="fixed grid h-dvh w-screen bg-black" class:cursor-none={!cursorVisible}>
 	{#if error}
 		<ErrorElement {authError} message={errorMessage} />
 	{:else if displayingAssets}
@@ -253,10 +253,3 @@
 		<LoadingElement />
 	{/if}
 </section>
-
-<style>
-	section {
-		height: 100vh;
-		height: 100dvh;
-	}
-</style>

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -204,7 +204,7 @@
 	});
 </script>
 
-<section class="fixed grid h-screen w-screen bg-black" class:cursor-none={!cursorVisible}>
+<section class="fixed grid h-dvh w-screen bg-black" class:cursor-none={!cursorVisible}>
 	{#if error}
 		<ErrorElement {authError} message={errorMessage} />
 	{:else if displayingAssets}


### PR DESCRIPTION
On mobile devices with a dynamic viewport size ("URL bar" can be shown/hidden), `h-screen` sets an element's height to the maximum possible viewport size.  This results in the top or bottom of the application being obscured by the URL bar.  
`h-dvh` instead uses the `dvh`  unit to set the element height to the current actual viewport height.  `dvh` is supported in all browsers, most since late 2022, except IE 11.

Only tested in Firefox and Chromium on Linux, Firefox and Chrome on Android, and Safari on iOS, as I am not set up to build and test the native clients.