### PR TITLE
Improve responsiveness when user manually requests prev/next image

### DIFF
--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -6,7 +6,6 @@ using ImmichFrame.Core.Logic;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Net.Http.Headers;
 
 namespace ImmichFrame.WebApi.Controllers
 {
@@ -51,8 +50,6 @@ namespace ImmichFrame.WebApi.Controllers
             var notification = new ImageRequestedNotification(id, clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
-            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
-
             return File(image.fileStream, image.ContentType, image.fileName); // returns a FileStreamResult
         }
 
@@ -65,8 +62,6 @@ namespace ImmichFrame.WebApi.Controllers
             var image = await _logic.GetImage(new Guid(randomImage.Id));
             var notification = new ImageRequestedNotification(new Guid(randomImage.Id), clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
-
-            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
 
             string randomImageBase64;
             using (var memoryStream = new MemoryStream())

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -6,6 +6,7 @@ using ImmichFrame.Core.Logic;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 
 namespace ImmichFrame.WebApi.Controllers
 {
@@ -50,6 +51,8 @@ namespace ImmichFrame.WebApi.Controllers
             var notification = new ImageRequestedNotification(id, clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
+            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
+
             return File(image.fileStream, image.ContentType, image.fileName); // returns a FileStreamResult
         }
 
@@ -62,6 +65,8 @@ namespace ImmichFrame.WebApi.Controllers
             var image = await _logic.GetImage(new Guid(randomImage.Id));
             var notification = new ImageRequestedNotification(new Guid(randomImage.Id), clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
+
+            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
 
             string randomImageBase64;
             using (var memoryStream = new MemoryStream())
@@ -76,7 +81,7 @@ namespace ImmichFrame.WebApi.Controllers
             string thumbHashBase64 = Convert.ToBase64String(byteArray);
 
             CultureInfo cultureInfo = new CultureInfo(_settings.Language);
-            string photoDateFormat = _settings.PhotoDateFormat!.Replace("''", "\\'"); 
+            string photoDateFormat = _settings.PhotoDateFormat!.Replace("''", "\\'");
             string photoDate = randomImage.LocalDateTime.ToString(photoDateFormat, cultureInfo) ?? string.Empty;
 
             var locationFormat = _settings.ImageLocationFormat ?? "City,State,Country";

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -10,6 +10,7 @@
 	import { configStore } from '$lib/stores/config.store';
 	import { Confetti } from 'svelte-confetti';
 	import { clientIdentifierStore } from '$lib/stores/persist.store';
+	import { slideshowStore } from '$lib/stores/slideshow.store';
 
 	api.init();
 
@@ -29,8 +30,8 @@
 		showPeopleDesc = true
 	}: Props = $props();
 	let split: boolean = $state(true);
-
-	let transitionDuration = ($configStore.transitionDuration ?? 1) * 1000;
+	let instantTransition = slideshowStore.instantTransition;
+	let transitionDuration = $derived($instantTransition ? 0 : ($configStore.transitionDuration ?? 1) * 1000);
 
 	let error: boolean = $state(false);
 	let loaded: boolean = $state(false);

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -23,7 +23,7 @@
 
 	let displayingAssets: api.AssetResponseDto[] = $state() as api.AssetResponseDto[];
 
-	const { restartProgress, stopProgress } = slideshowStore;
+	const { restartProgress, stopProgress, instantTransition } = slideshowStore;
 
 	let progressBarStatus: ProgressBarStatus = $state(ProgressBarStatus.Playing);
 	let progressBar: ProgressBar = $state() as ProgressBar;
@@ -78,8 +78,9 @@
 		}
 	}
 
-	const handleDone = async (previous: boolean = false) => {
+	const handleDone = async (previous: boolean = false, instant: boolean = false) => {
 		progressBar.restart(false);
+		$instantTransition = instant;
 		if (previous) await getPreviousAssets();
 		else await getNextAssets();
 		progressBar.play();
@@ -224,10 +225,10 @@
 
 		<OverlayControls
 			on:next={async () => {
-				await handleDone();
+				await handleDone(false, true);
 			}}
 			on:back={async () => {
-				await handleDone(true);
+				await handleDone(true, true);
 			}}
 			on:pause={async () => {
 				if (progressBarStatus == ProgressBarStatus.Paused) {

--- a/immichFrame.Web/src/lib/stores/slideshow.store.ts
+++ b/immichFrame.Web/src/lib/stores/slideshow.store.ts
@@ -12,6 +12,7 @@ function createSlideshowStore() {
   const stopState = writable<boolean>(false);
 
   const slideshowState = writable<SlideshowState>(SlideshowState.None);
+  const instantTransition = writable<boolean>(false);
 
   return {
     restartProgress: {
@@ -36,7 +37,8 @@ function createSlideshowStore() {
         }
       },
     },
-    slideshowState
+    slideshowState,
+    instantTransition,
   };
 }
 


### PR DESCRIPTION
Manually paging through images currently feels somewhat sluggish due to a combination of transition time (which is of course desirable for non-manual transitions) and long image load times when connected to a remote api server.

This PR includes two proposed changes in order to improve responsiveness:
* set transition duration to zero when the user manually requests the previous or next image (and then set it back to the configured value at the next automatic transition)
* set cache-control headers to store images in the browser cache for up to one week

I'd be happy to rework these if another approach would be preferable, please let me know.

There's one thing which I did _not_ attempt to implement, but which I think could be quite beneficial: pre-loading the next/"on-deck" image.  I didn't see an easy way to incorporate this into the current structure of the code but I think it could further improve perceived UI responsiveness and also improve the consistency of automatic slide advances.