### PR TITLE
Fix: Add animation fill on image zoom

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -168,16 +168,16 @@
 
 <style>
 	.zoom-in {
-		animation: zoom-in var(--interval) ease-out normal;
+		animation: zoom-in var(--interval) ease-out normal forwards;
 	}
 	.zoom-in-person {
-		animation: zoom-in-person var(--interval) ease-out normal;
+		animation: zoom-in-person var(--interval) ease-out normal forwards;
 	}
 	.zoom-out {
-		animation: zoom-out var(--interval) ease-out normal;
+		animation: zoom-out var(--interval) ease-out normal forwards;
 	}
 	.zoom-out-person {
-		animation: zoom-out-person var(--interval) ease-out normal;
+		animation: zoom-out-person var(--interval) ease-out normal forwards;
 	}
 
 	@keyframes zoom-in {


### PR DESCRIPTION
The image zoom effect "jumps" at the end of its animation back to its un-transformed state.  Normally the slideshow will have moved on before this happens, due to the 2s extra animation length, but if it is paused or the next image takes a particularly long time to load the jump will be visible to the user.

This PR adds a forwards animation fill to all the image zoom animations which should fix the issue.  (The pure `zoom-out` is currently unaffected since `scale(1)` is an identity transform, but I think it's probably good to put the fill in now in case of future changes to the animation.)