### PR TITLE
Feat: Pre-fetch and cache images

### DIFF
--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -6,6 +6,7 @@ using ImmichFrame.Core.Logic;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Net.Http.Headers;
 
 namespace ImmichFrame.WebApi.Controllers
 {
@@ -50,6 +51,8 @@ namespace ImmichFrame.WebApi.Controllers
             var notification = new ImageRequestedNotification(id, clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
 
+            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
+
             return File(image.fileStream, image.ContentType, image.fileName); // returns a FileStreamResult
         }
 
@@ -62,6 +65,8 @@ namespace ImmichFrame.WebApi.Controllers
             var image = await _logic.GetImage(new Guid(randomImage.Id));
             var notification = new ImageRequestedNotification(new Guid(randomImage.Id), clientIdentifier);
             _ = _logic.SendWebhookNotification(notification);
+
+            Response.Headers[HeaderNames.CacheControl] = "private, max-age=604800";
 
             string randomImageBase64;
             using (var memoryStream = new MemoryStream())
@@ -76,7 +81,7 @@ namespace ImmichFrame.WebApi.Controllers
             string thumbHashBase64 = Convert.ToBase64String(byteArray);
 
             CultureInfo cultureInfo = new CultureInfo(_settings.Language);
-            string photoDateFormat = _settings.PhotoDateFormat!.Replace("''", "\\'"); 
+            string photoDateFormat = _settings.PhotoDateFormat!.Replace("''", "\\'");
             string photoDate = randomImage.LocalDateTime.ToString(photoDateFormat, cultureInfo) ?? string.Empty;
 
             var locationFormat = _settings.ImageLocationFormat ?? "City,State,Country";

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -10,6 +10,7 @@
 	import { configStore } from '$lib/stores/config.store';
 	import { Confetti } from 'svelte-confetti';
 	import { clientIdentifierStore } from '$lib/stores/persist.store';
+	import { slideshowStore } from '$lib/stores/slideshow.store';
 
 	api.init();
 
@@ -29,8 +30,8 @@
 		showPeopleDesc = true
 	}: Props = $props();
 	let split: boolean = $state(true);
-
-	let transitionDuration = ($configStore.transitionDuration ?? 1) * 1000;
+	let instantTransition = slideshowStore.instantTransition;
+	let transitionDuration = $derived($instantTransition ? 0 : ($configStore.transitionDuration ?? 1) * 1000);
 
 	let error: boolean = $state(false);
 	let loaded: boolean = $state(false);

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -61,7 +61,7 @@
 	<ErrorElement />
 {:else if loaded}
 	{#key images}
-		<div class="grid absolute h-screen w-screen">
+		<div class="grid absolute h-screen w-screen" transition:fade={{ duration: transitionDuration }}>
 			{#if split}
 				<div class="grid grid-cols-2">
 					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-screen">

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -15,7 +15,11 @@
 	api.init();
 
 	interface Props {
-		sourceAssets: AssetResponseDto[];
+		images: [string, AssetResponseDto][];
+		error?: boolean;
+		loaded?: boolean;
+		split?: boolean;
+		hasBday?: boolean;
 		showLocation?: boolean;
 		showPhotoDate?: boolean;
 		showImageDesc?: boolean;
@@ -23,80 +27,18 @@
 	}
 
 	let {
-		sourceAssets,
+		images,
+		error = false,
+		loaded = false,
+		split = false,
+		hasBday = false,
 		showLocation = true,
 		showPhotoDate = true,
 		showImageDesc = true,
 		showPeopleDesc = true
 	}: Props = $props();
-	let split: boolean = $state(true);
 	let instantTransition = slideshowStore.instantTransition;
 	let transitionDuration = $derived($instantTransition ? 0 : ($configStore.transitionDuration ?? 1) * 1000);
-
-	let error: boolean = $state(false);
-	let loaded: boolean = $state(false);
-
-	let images: [string, AssetResponseDto][] = $state() as [string, AssetResponseDto][];
-
-	function hasBirthday(assets: AssetResponseDto[]) {
-		let today = new Date();
-		let hasBday: boolean = false;
-
-		for (let asset of assets) {
-			for (let person of asset.people ?? new Array()) {
-				let birthdate = new Date(person.birthDate ?? '');
-				if (birthdate.getDate() === today.getDate() && birthdate.getMonth() === today.getMonth()) {
-					hasBday = true;
-					break;
-				}
-			}
-			if (hasBday) break;
-		}
-
-		return hasBday;
-	}
-
-	function getImageUrl(image: Blob) {
-		return URL.createObjectURL(image);
-	}
-
-	async function loadImages(assets: AssetResponseDto[]) {
-		let newImages = [];
-
-		for (let asset of assets) {
-			let img = await loadImage(asset);
-			newImages.push(img);
-		}
-
-		if (assets.length == 2) {
-			split = true;
-		} else {
-			split = false;
-		}
-		images = newImages;
-		loaded = true;
-	}
-
-	async function loadImage(a: AssetResponseDto) {
-		try {
-			let req = await api.getImage(a.id, { clientIdentifier: $clientIdentifierStore });
-
-			if (req.status != 200) {
-				error = true;
-				return ['', a] as [string, AssetResponseDto];
-			}
-
-			error = false;
-			return [getImageUrl(req.data), a] as [string, AssetResponseDto];
-		} catch {
-			error = true;
-		}
-		return ['', a] as [string, AssetResponseDto];
-	}
-	run(() => {
-		loadImages(sourceAssets);
-	});
-	let hasBday = $derived(hasBirthday(sourceAssets));
 </script>
 
 {#if hasBday}
@@ -119,7 +61,7 @@
 	<ErrorElement />
 {:else if loaded}
 	{#key images}
-		<div class="grid absolute h-screen w-screen" transition:fade={{ duration: transitionDuration }}>
+		<div class="grid absolute h-screen w-screen">
 			{#if split}
 				<div class="grid grid-cols-2">
 					<div id="image_portrait_1" class="relative grid border-r-2 border-primary h-screen">

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -23,7 +23,7 @@
 
 	let displayingAssets: api.AssetResponseDto[] = $state() as api.AssetResponseDto[];
 
-	const { restartProgress, stopProgress } = slideshowStore;
+	const { restartProgress, stopProgress, instantTransition } = slideshowStore;
 
 	let progressBarStatus: ProgressBarStatus = $state(ProgressBarStatus.Playing);
 	let progressBar: ProgressBar = $state() as ProgressBar;
@@ -78,8 +78,9 @@
 		}
 	}
 
-	const handleDone = async (previous: boolean = false) => {
+	const handleDone = async (previous: boolean = false, instant: boolean = false) => {
 		progressBar.restart(false);
+		$instantTransition = instant;
 		if (previous) await getPreviousAssets();
 		else await getNextAssets();
 		progressBar.play();
@@ -224,10 +225,10 @@
 
 		<OverlayControls
 			on:next={async () => {
-				await handleDone();
+				await handleDone(false, true);
 			}}
 			on:back={async () => {
-				await handleDone(true);
+				await handleDone(true, true);
 			}}
 			on:pause={async () => {
 				if (progressBarStatus == ProgressBarStatus.Paused) {

--- a/immichFrame.Web/src/lib/stores/slideshow.store.ts
+++ b/immichFrame.Web/src/lib/stores/slideshow.store.ts
@@ -12,6 +12,7 @@ function createSlideshowStore() {
   const stopState = writable<boolean>(false);
 
   const slideshowState = writable<SlideshowState>(SlideshowState.None);
+  const instantTransition = writable<boolean>(false);
 
   return {
     restartProgress: {
@@ -36,7 +37,8 @@ function createSlideshowStore() {
         }
       },
     },
-    slideshowState
+    slideshowState,
+    instantTransition,
   };
 }
 


### PR DESCRIPTION
Okay, this might need some additional work but I want to get your feedback on the approach (I've reimplemented it a couple of times, this is the best I could find).

This PR would:
* move image loading to home-page
* create a dictionary of loadImage promises, which is updated when the slideshow advances
* load data into imagesState by awaiting those promises
* set cache headers to store images for one week (this is currently relied upon for loading previous images, but we could keep those in JS as well with this approach if we wanted to)

Some things I'm not sure about:
* PRELOAD_IMAGES (the distance ahead in the backlog to fetch) could be configurable?  If it was it should probably also be capped so people don't set it to some huge number.
* It might be worthwhile to construct some kind of intermediate component to handle image loading?  home-page is getting kind of crowded.
* 3rob3 mentioned that caching is currently intentionally disabled for the native/webview clients - I was wondering what the reason for this is.  If it's not always undesirable, maybe it could also be user configurable?