### PR TITLE
Add version, version logging, and version endpoint

### DIFF
--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -23,5 +23,15 @@ namespace ImmichFrame.WebApi.Controllers
         {
             return (WebClientSettings)_settings;
         }
+        [HttpGet("version")]
+        public IActionResult GetVersion()
+        {
+            var version = System.Reflection.Assembly
+                .GetExecutingAssembly()
+                .GetName()
+                .Version?.ToString() ?? "unknown";
+
+            return Ok(new { version });
+        }
     }
 }

--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -23,15 +23,11 @@ namespace ImmichFrame.WebApi.Controllers
         {
             return (WebClientSettings)_settings;
         }
-        [HttpGet("GetVersion")]
-        public IActionResult GetVersion()
-        {
-            var version = System.Reflection.Assembly
-                .GetExecutingAssembly()
-                .GetName()
-                .Version?.ToString() ?? "unknown";
 
-            return Ok(new { version });
+        [HttpGet("GetVersion")]
+        public string GetVersion()
+        {
+            return System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
         }
     }
 }

--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -23,7 +23,7 @@ namespace ImmichFrame.WebApi.Controllers
         {
             return (WebClientSettings)_settings;
         }
-        [HttpGet("version")]
+        [HttpGet("GetVersion")]
         public IActionResult GetVersion()
         {
             var version = System.Reflection.Assembly

--- a/ImmichFrame.WebApi/ImmichFrame.WebApi.csproj
+++ b/ImmichFrame.WebApi/ImmichFrame.WebApi.csproj
@@ -7,6 +7,7 @@
     <SpaRoot>..\immichFrame.Web</SpaRoot>
     <SpaProxyLaunchCommand>npm run dev -- --host</SpaProxyLaunchCommand>
     <SpaProxyServerUrl>https://localhost:5173</SpaProxyServerUrl>
+    <Version>1.0.24.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -5,9 +5,13 @@ using ImmichFrame.Core.Logic;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authentication;
 using System.Text.Json;
+using System.Reflection;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.AddConsole();
+//log the version number
+var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+Console.WriteLine($"=== Version {version} ===");
 
 // Add services to the container.
 


### PR DESCRIPTION
There is currently no way to see backend version number. This will add it to log and also expose an endpoint that can be checked via a client if ever required.