### PR TITLE
fix: Add text shadow to weather data display

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -62,7 +62,7 @@
 	</p>
 	{#if weather}
 		<div id="clockweather">
-			<div id="clockweatherinfo" class="text-xl sm:text-xl md:text-2xl lg:text-3xl font-semibold">
+			<div id="clockweatherinfo" class="text-xl sm:text-xl md:text-2xl lg:text-3xl font-semibold text-shadow-sm">
 				{weather.location},
 				{weather.temperature?.toFixed(1)}
 				{weather.unit}


### PR DESCRIPTION
## Changes
Added shadow to the weather data display which was missing.
Applied `text-shadow-sm` class to the clockweatherinfo element,
matching the styling used in date display and weather description.

## Issue
Fixes #322