### PR TITLE
Fix: Description for memory assets (x years ago)

### DIFF
--- a/ImmichFrame.Core/Api/AssetResponseDto.cs
+++ b/ImmichFrame.Core/Api/AssetResponseDto.cs
@@ -7,25 +7,6 @@ namespace ImmichFrame.Core.Api
     public partial class AssetResponseDto
     {
         [JsonIgnore]
-        private string? _imageDesc;
-
-        [JsonIgnore]
-        public string ImageDesc
-        {
-            get
-            {
-                if (string.IsNullOrWhiteSpace(_imageDesc))
-                    return this.ExifInfo?.Description ?? string.Empty;
-
-                return _imageDesc;
-            }
-            set
-            {
-                _imageDesc = value;
-            }
-        }
-
-        [JsonIgnore]
         public Stream? ThumbhashImage => GetThumbHashStream();
 
         private Stream? GetThumbHashStream()

--- a/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/ImmichFrameLogic.cs
@@ -227,7 +227,7 @@ namespace ImmichFrame.Core.Logic
                 foreach (var lane in memoryLane)
                 {
                     var assets = lane.Assets.ToList();
-                    assets.ForEach(asset => asset.ImageDesc = $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
+                    assets.ForEach(asset => asset.ExifInfo.Description = $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
 
                     allAssets.AddRange(assets);
                 }

--- a/ImmichFrame.Core/Logic/OptimizedImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/OptimizedImmichFrameLogic.cs
@@ -192,7 +192,7 @@ public class OptimizedImmichFrameLogic : IImmichFrameLogic, IDisposable
             foreach (var lane in memoryLane)
             {
                 var assets = lane.Assets.ToList();
-                assets.ForEach(asset => asset.ImageDesc = $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
+                assets.ForEach(asset => asset.ExifInfo.Description = $"{lane.YearsAgo} {(lane.YearsAgo == 1 ? "year" : "years")} ago");
 
                 memoryAssets.AddRange(assets);
             }


### PR DESCRIPTION
Closes #329

This is just to fix how it used to work. I don't really like how the description gets overwritten by 'x years ago'.