### PR TITLE
Feat: Fetch asset metadata for images without people

### DIFF
--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -257,7 +257,14 @@
 		if (req.status != 200) {
 			return ['', a] as [string, api.AssetResponseDto];
 		}
-		return [getImageUrl(req.data), a] as [string, api.AssetResponseDto];
+
+		// if the people array is already populated, there is no need to call the API again
+		if ((a.people ?? []).length > 0) {
+			return [getImageUrl(req.data), a] as [string, api.AssetResponseDto];
+		}
+		let assetInfoRequest = await api.getAssetInfo(a.id);
+
+		return [getImageUrl(req.data), assetInfoRequest.data] as [string, api.AssetResponseDto];
 	}
 
 	function getImageUrl(image: Blob) {


### PR DESCRIPTION
immich does not return people data when using the filtering for albums. This change (pre)fetches this data. This will result in e.g. people being displayed if you have an album filter active.