### PR TITLE
Fix: Logo flickering

### DIFF
--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -116,5 +116,7 @@
 		</div>
 	{/key}
 {:else}
-	<LoadingElement />
+	<div class="grid absolute h-dvh w-screen">
+		<LoadingElement />
+	</div>
 {/if}


### PR DESCRIPTION
logo moving causes the flicker. This seems to fix it for me.
Closes #335 