### PR TITLE
Feat: Display more details

### DIFF
--- a/ImmichFrame.Core/Interfaces/IClientSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IClientSettings.cs
@@ -7,6 +7,7 @@
 
     public interface IClientSettings
     {
+        public string ImmichServerUrl { get; set; }
         public string Margin { get; set; }
         public int Interval { get; set; }
         public double TransitionDuration { get; set; }

--- a/ImmichFrame.WebApi/Models/WebClientSettings.cs
+++ b/ImmichFrame.WebApi/Models/WebClientSettings.cs
@@ -6,6 +6,7 @@ namespace ImmichFrame.WebApi.Models
 {
     public class WebClientSettings : IWebClientSettings
     {
+        public string ImmichServerUrl { get; set; }
         public string Margin { get; set; } = "0,0,0,0";
         public int Interval { get; set; } = 45;
         public double TransitionDuration { get; set; } = 1;

--- a/ImmichFrame.WebApi/Models/WebClientSettings.cs
+++ b/ImmichFrame.WebApi/Models/WebClientSettings.cs
@@ -6,7 +6,7 @@ namespace ImmichFrame.WebApi.Models
 {
     public class WebClientSettings : IWebClientSettings
     {
-        public string ImmichServerUrl { get; set; }
+        public string ImmichServerUrl { get; set; } = string.Empty;
         public string Margin { get; set; } = "0,0,0,0";
         public int Interval { get; set; } = 45;
         public double TransitionDuration { get; set; } = 1;

--- a/immichFrame.Web/package.json
+++ b/immichFrame.Web/package.json
@@ -13,6 +13,7 @@
 		"api": "oazapfts http://localhost:5217/swagger/v1/swagger.json src/lib/immichFrameApi.ts"
 	},
 	"devDependencies": {
+		"@castlenine/svelte-qrcode": "^2.3.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/adapter-static": "^3.0.5",
 		"@sveltejs/kit": "^2.8.4",
@@ -42,7 +43,6 @@
 		"date-fns": "^4.1.0",
 		"oazapfts": "^6.1.0",
 		"openapi-fetch": "^0.12.0",
-		"svelte-qrcode": "^1.0.1",
 		"thumbhash": "^0.1.1"
 	}
 }

--- a/immichFrame.Web/package.json
+++ b/immichFrame.Web/package.json
@@ -42,6 +42,7 @@
 		"date-fns": "^4.1.0",
 		"oazapfts": "^6.1.0",
 		"openapi-fetch": "^0.12.0",
+		"svelte-qrcode": "^1.0.1",
 		"thumbhash": "^0.1.1"
 	}
 }

--- a/immichFrame.Web/src/lib/components/elements/asset-info.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset-info.svelte
@@ -43,7 +43,6 @@
 		return Array.from(locationParts).join(', ');
 	}
 	let assetDate = $derived(asset.exifInfo?.dateTimeOriginal);
-	console.log(asset.exifInfo);
 	let desc = $derived(asset.exifInfo?.description ?? '');
 	let time = $derived(assetDate ? new Date(assetDate) : null);
 	const selectedLocale = $configStore.language;

--- a/immichFrame.Web/src/lib/components/elements/image-component.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image-component.svelte
@@ -25,6 +25,7 @@
 		showAlbumName?: boolean;
 		imageFill?: boolean;
 		imageZoom?: boolean;
+		showInfo: boolean;
 	}
 
 	let {
@@ -40,7 +41,8 @@
 		showPeopleDesc = true,
 		showAlbumName = true,
 		imageFill = false,
-		imageZoom = false
+		imageZoom = false,
+		showInfo = $bindable(false)
 	}: Props = $props();
 	let instantTransition = slideshowStore.instantTransition;
 	let transitionDuration = $derived(
@@ -83,6 +85,7 @@
 							{showAlbumName}
 							{imageFill}
 							{imageZoom}
+							bind:showInfo
 						/>
 					</div>
 					<div id="image_portrait_2" class="relative grid border-l-2 border-primary h-dvh">
@@ -97,6 +100,7 @@
 							{showAlbumName}
 							{imageFill}
 							{imageZoom}
+							bind:showInfo
 						/>
 					</div>
 				</div>
@@ -112,6 +116,7 @@
 						{showAlbumName}
 						{imageFill}
 						{imageZoom}
+						bind:showInfo
 					/>
 				</div>
 			{/if}

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -94,7 +94,7 @@
 </script>
 
 {#if showInfo}
-	<ImageOverlay asset={image[1]} albums={image[2]} bind:showInfo />
+	<ImageOverlay asset={image[1]} albums={image[2]} />
 {/if}
 
 <div class="immichframe_image relative place-self-center overflow-hidden">

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -6,7 +6,8 @@
 	} from '$lib/immichFrameApi';
 	import { decodeBase64 } from '$lib/utils';
 	import { thumbHashToDataURL } from 'thumbhash';
-	import AssetInfo from './asset-info.svelte';
+	import AssetInfo from '$lib/components/elements/asset-info.svelte';
+	import ImageOverlay from '$lib/components/elements/imageoverlay/image-overlay.svelte';
 
 	interface Props {
 		image: [url: string, asset: AssetResponseDto, albums: AlbumResponseDto[]];
@@ -19,6 +20,7 @@
 		imageZoom: boolean;
 		interval: number;
 		multi?: boolean;
+		showInfo: boolean;
 	}
 
 	let {
@@ -31,7 +33,8 @@
 		imageFill,
 		imageZoom,
 		interval,
-		multi = false
+		multi = false,
+		showInfo = $bindable(false)
 	}: Props = $props();
 
 	let debug = false;
@@ -89,6 +92,10 @@
 		return 0.5 > Math.random();
 	}
 </script>
+
+{#if showInfo}
+	<ImageOverlay asset={image[1]} albums={image[2]} />
+{/if}
 
 <div class="immichframe_image relative place-self-center overflow-hidden">
 	<!-- Container with zoom-effect -->

--- a/immichFrame.Web/src/lib/components/elements/image.svelte
+++ b/immichFrame.Web/src/lib/components/elements/image.svelte
@@ -94,7 +94,7 @@
 </script>
 
 {#if showInfo}
-	<ImageOverlay asset={image[1]} albums={image[2]} />
+	<ImageOverlay asset={image[1]} albums={image[2]} bind:showInfo />
 {/if}
 
 <div class="immichframe_image relative place-self-center overflow-hidden">

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -4,26 +4,46 @@
 		type AssetResponseDto,
 		type ExifResponseDto
 	} from '$lib/immichFrameApi';
-	import { mdiAccount, mdiCamera, mdiFile, mdiImageAlbum, mdiStar, mdiText } from '@mdi/js';
+	import {
+		mdiAccount,
+		mdiCamera,
+		mdiClose,
+		mdiFile,
+		mdiImageAlbum,
+		mdiStar,
+		mdiText
+	} from '@mdi/js';
 	import OverlayItem from './overlay-item.svelte';
 	import OverlayQr from './overlay-qr.svelte';
 	import { configStore } from '$lib/stores/config.store';
+	import Icon from '../icon.svelte';
 
 	interface Props {
 		asset: AssetResponseDto;
 		albums: AlbumResponseDto[];
+		showInfo: boolean;
 	}
+	let { asset, albums, showInfo = $bindable(false) }: Props = $props();
 
-	let { asset, albums }: Props = $props();
 	let availablePeople = $derived(asset.people?.filter((x) => x.name));
-
 	let exif: ExifResponseDto = $derived(asset.exifInfo ?? ({} as ExifResponseDto));
+
+	function close() {
+		showInfo = false;
+	}
 </script>
 
-<div class="p-0 absolute w-full h-full z-[50]">
+<div class="p-0 absolute w-full h-full z-[200]">
 	<div
 		class="bg-black bg-opacity-70 w-full h-full relative items-center justify-center flex pt-32 pb-8 max-h-full overflow-auto"
 	>
+		<button class="absolute top-0 right-0 m-4 text-primary" onclick={close}>
+			<Icon
+				path={mdiClose}
+				size={30}
+				class="hover:scale-110 transition-transform duration-200 text-primary"
+			/>
+		</button>
 		<div class="flex h-full flex-col gap-5">
 			<div class="w-fit flex grow flex-col gap-3">
 				{#if asset.originalFileName}

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -86,7 +86,7 @@
 				{/if}
 			</div>
 
-			<OverlayQr baseUrl={$configStore.immichServerUrl ?? ''} c id={asset.id} />
+			<OverlayQr baseUrl={$configStore.immichServerUrl ?? ''} id={asset.id} />
 		</div>
 	</div>
 </div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import {
+		type AlbumResponseDto,
+		type AssetResponseDto,
+		type ExifResponseDto
+	} from '$lib/immichFrameApi';
+	import { mdiAccount, mdiCamera, mdiFile, mdiImageAlbum, mdiStar, mdiText } from '@mdi/js';
+	import OverlayItem from './overlay-item.svelte';
+
+	interface Props {
+		asset: AssetResponseDto;
+		albums: AlbumResponseDto[];
+	}
+
+	let { asset, albums }: Props = $props();
+	let availablePeople = $derived(asset.people?.filter((x) => x.name));
+
+	let exif: ExifResponseDto = $derived(asset.exifInfo ?? ({} as ExifResponseDto));
+</script>
+
+<div class="p-0 absolute w-full h-full">
+	<div
+		class="bg-black bg-opacity-70 z-[50] p-32 w-full h-full relative items-center justify-center flex"
+	>
+		<div class="w-fit flex flex-col gap-3">
+			{#if asset.originalFileName}
+				<OverlayItem
+					icon={mdiFile}
+					header={asset.originalFileName}
+					items={[
+						`Size: ${((exif.fileSizeInByte ?? 0) / (1024 * 1024)).toFixed(1)} MB`,
+						`Dimensions: ${exif.exifImageWidth} x ${exif.exifImageHeight}`
+					]}
+				/>
+			{/if}
+			<OverlayItem
+				icon={mdiCamera}
+				header="{exif.make} {exif.model}"
+				items={[
+					`ISO: ${exif.iso}`,
+					`Aperture: f/${exif.fNumber}`,
+					`Shutter: 1/${exif.iso}`,
+					`Focal Length: ${exif.focalLength} mm`
+				]}
+			/>
+			{#if exif.description}
+				<OverlayItem icon={mdiText} header={exif.description} />
+			{/if}
+			{#if exif.rating}
+				<OverlayItem icon={mdiStar} header="Rating" items={[exif.rating.toString()]} />
+			{/if}
+			{#if availablePeople && availablePeople.length > 0}
+				<OverlayItem icon={mdiAccount} header="People" items={availablePeople.map((x) => x.name)} />
+			{/if}
+			{#if albums && albums.length > 0}
+				<OverlayItem icon={mdiImageAlbum} header="Album" items={albums.map((x) => x.albumName)} />
+			{/if}
+		</div>
+	</div>
+</div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -6,6 +6,8 @@
 	} from '$lib/immichFrameApi';
 	import { mdiAccount, mdiCamera, mdiFile, mdiImageAlbum, mdiStar, mdiText } from '@mdi/js';
 	import OverlayItem from './overlay-item.svelte';
+	import OverlayQr from './overlay-qr.svelte';
+	import { configStore } from '$lib/stores/config.store';
 
 	interface Props {
 		asset: AssetResponseDto;
@@ -20,41 +22,49 @@
 
 <div class="p-0 absolute w-full h-full">
 	<div
-		class="bg-black bg-opacity-70 z-[50] p-32 w-full h-full relative items-center justify-center flex"
+		class="bg-black bg-opacity-70 z-[50] w-full h-full relative items-center justify-center flex pt-32"
 	>
-		<div class="w-fit flex flex-col gap-3">
-			{#if asset.originalFileName}
+		<div class="flex h-full flex-col gap-5">
+			<div class="w-fit flex grow flex-col gap-3">
+				{#if asset.originalFileName}
+					<OverlayItem
+						icon={mdiFile}
+						header={asset.originalFileName}
+						items={[
+							`Size: ${((exif.fileSizeInByte ?? 0) / (1024 * 1024)).toFixed(1)} MB`,
+							`Dimensions: ${exif.exifImageWidth} x ${exif.exifImageHeight}`
+						]}
+					/>
+				{/if}
 				<OverlayItem
-					icon={mdiFile}
-					header={asset.originalFileName}
+					icon={mdiCamera}
+					header="{exif.make} {exif.model}"
 					items={[
-						`Size: ${((exif.fileSizeInByte ?? 0) / (1024 * 1024)).toFixed(1)} MB`,
-						`Dimensions: ${exif.exifImageWidth} x ${exif.exifImageHeight}`
+						`ISO: ${exif.iso}`,
+						`Aperture: f/${exif.fNumber}`,
+						`Shutter: 1/${exif.iso}`,
+						`Focal Length: ${exif.focalLength} mm`
 					]}
 				/>
-			{/if}
-			<OverlayItem
-				icon={mdiCamera}
-				header="{exif.make} {exif.model}"
-				items={[
-					`ISO: ${exif.iso}`,
-					`Aperture: f/${exif.fNumber}`,
-					`Shutter: 1/${exif.iso}`,
-					`Focal Length: ${exif.focalLength} mm`
-				]}
-			/>
-			{#if exif.description}
-				<OverlayItem icon={mdiText} header={exif.description} />
-			{/if}
-			{#if exif.rating}
-				<OverlayItem icon={mdiStar} header="Rating" items={[exif.rating.toString()]} />
-			{/if}
-			{#if availablePeople && availablePeople.length > 0}
-				<OverlayItem icon={mdiAccount} header="People" items={availablePeople.map((x) => x.name)} />
-			{/if}
-			{#if albums && albums.length > 0}
-				<OverlayItem icon={mdiImageAlbum} header="Album" items={albums.map((x) => x.albumName)} />
-			{/if}
+				{#if exif.description}
+					<OverlayItem icon={mdiText} header={exif.description} />
+				{/if}
+				{#if exif.rating}
+					<OverlayItem icon={mdiStar} header="Rating" items={[exif.rating.toString()]} />
+				{/if}
+				{#if availablePeople && availablePeople.length > 0}
+					<OverlayItem
+						icon={mdiAccount}
+						header="People"
+						items={availablePeople.map((x) => x.name)}
+					/>
+				{/if}
+				{#if albums && albums.length > 0}
+					<OverlayItem icon={mdiImageAlbum} header="Album" items={albums.map((x) => x.albumName)} />
+				{/if}
+			</div>
+
+			<OverlayQr baseUrl={$configStore.immichServerUrl ?? ''} id={asset.id} />
 		</div>
 	</div>
 </div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -20,9 +20,9 @@
 	let exif: ExifResponseDto = $derived(asset.exifInfo ?? ({} as ExifResponseDto));
 </script>
 
-<div class="p-0 absolute w-full h-full">
+<div class="p-0 absolute w-full h-full z-[50]">
 	<div
-		class="bg-black bg-opacity-70 z-[50] w-full h-full relative items-center justify-center flex pt-32"
+		class="bg-black bg-opacity-70 w-full h-full relative items-center justify-center flex pt-32 pb-8 max-h-full overflow-auto"
 	>
 		<div class="flex h-full flex-col gap-5">
 			<div class="w-fit flex grow flex-col gap-3">
@@ -36,6 +36,7 @@
 						]}
 					/>
 				{/if}
+				<!-- TODO check if exists -->
 				<OverlayItem
 					icon={mdiCamera}
 					header="{exif.make} {exif.model}"

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -56,17 +56,18 @@
 						]}
 					/>
 				{/if}
-				<!-- TODO check if exists -->
-				<OverlayItem
-					icon={mdiCamera}
-					header="{exif.make} {exif.model}"
-					items={[
-						`ISO: ${exif.iso}`,
-						`Aperture: f/${exif.fNumber}`,
-						`Shutter: 1/${exif.iso}`,
-						`Focal Length: ${exif.focalLength} mm`
-					]}
-				/>
+				{#if exif.make || exif.model || exif.fNumber || exif.exposureTime || exif.focalLength || exif.iso}
+					<OverlayItem
+						icon={mdiCamera}
+						header={`${exif.make ?? ''} ${exif.model ?? ''}`.trim()}
+						items={[
+							exif.fNumber ? `ƒ/${exif.fNumber}` : null,
+							exif.exposureTime ? `${exif.exposureTime} s` : null,
+							exif.focalLength ? `${exif.focalLength} mm` : null,
+							exif.iso ? `ISO ${exif.iso}` : null
+						].filter((item): item is string => item !== null)}
+					/>
+				{/if}
 				{#if exif.description}
 					<OverlayItem icon={mdiText} header={exif.description} />
 				{/if}

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -17,20 +17,18 @@
 	import OverlayQr from './overlay-qr.svelte';
 	import { configStore } from '$lib/stores/config.store';
 	import Icon from '../icon.svelte';
+	import { getContext } from 'svelte';
 
 	interface Props {
 		asset: AssetResponseDto;
 		albums: AlbumResponseDto[];
-		showInfo: boolean;
 	}
-	let { asset, albums, showInfo = $bindable(false) }: Props = $props();
+	let { asset, albums }: Props = $props();
 
 	let availablePeople = $derived(asset.people?.filter((x) => x.name));
 	let exif: ExifResponseDto = $derived(asset.exifInfo ?? ({} as ExifResponseDto));
 
-	function close() {
-		showInfo = false;
-	}
+	let close = getContext<() => void>('close');
 </script>
 
 <div class="p-0 absolute w-full h-full z-[200]">

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -35,13 +35,13 @@
 
 <div class="p-0 absolute w-full h-full z-[200]">
 	<div
-		class="bg-black bg-opacity-70 w-full h-full relative items-center justify-center flex pt-32 pb-8 max-h-full overflow-auto"
+		class="info-overlay-background bg-black bg-opacity-70 w-full h-full relative items-center justify-center flex pt-32 pb-8 max-h-full overflow-auto"
 	>
 		<button class="absolute top-0 right-0 m-4 text-primary" onclick={close}>
 			<Icon
 				path={mdiClose}
 				size={30}
-				class="hover:scale-110 transition-transform duration-200 text-primary"
+				class="info-overlay-close hover:scale-110 transition-transform duration-200 text-primary"
 			/>
 		</button>
 		<div class="flex h-full flex-col gap-5">
@@ -86,7 +86,7 @@
 				{/if}
 			</div>
 
-			<OverlayQr baseUrl={$configStore.immichServerUrl ?? ''} id={asset.id} />
+			<OverlayQr baseUrl={$configStore.immichServerUrl ?? ''} c id={asset.id} />
 		</div>
 	</div>
 </div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-item.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-item.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import Icon from '../icon.svelte';
+	import { mdiTestTube } from '@mdi/js';
+
+	interface Props {
+		icon?: string;
+		header: string;
+		items?: string[];
+	}
+	let { icon = mdiTestTube, header, items = [] }: Props = $props();
+</script>
+
+<div class="text-xl text-primary text-left w-fit flex flex-col">
+	<span class="flex gap-2 items-center"><Icon path={icon} class="info-icon" />{header}</span>
+	{#if items.length > 0}
+		<span>{items.map((x) => x).join(', ')}</span>
+	{/if}
+</div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -11,13 +11,13 @@
 </script>
 
 <div
-	class="border-4 border-white rounded-lg self-center min-h-[128px] min-w-[128px] grow max-h-[200px] max-w-[200px] aspect-[1/1]"
+	class="info-overlay-qrcode border-4 border-white rounded-lg self-center min-h-[128px] min-w-[128px] grow max-h-[200px] max-w-[200px] aspect-[1/1]"
 >
 	<QrCode data={imageUrl} isResponsive />
 </div>
 <a
 	href={imageUrl}
 	target="_blank"
-	class="text-xl w-fit self-center rounded-md p-2 m-2 text-center text-secondary bg-primary"
+	class="info-overlay-openimmich text-xl w-fit self-center rounded-md p-2 m-2 text-center text-secondary bg-primary"
 	>Open in immich</a
 >

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import QrCode from 'svelte-qrcode';
+
+	interface Props {
+		baseUrl: string;
+		id: string;
+	}
+	let { baseUrl, id }: Props = $props();
+</script>
+
+<div class="border-8 border-white rounded-lg m-5 self-center">
+	<QrCode value={baseUrl + '/photos/' + id} />
+</div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -13,8 +13,9 @@
 <div class="border-8 border-white rounded-lg self-center">
 	<QrCode value={imageUrl} />
 </div>
-<!-- <a
+<a
 	href={imageUrl}
-	class="text-xl border-gray-400 border-2 rounded-md p-2 m-2 text-center text-primary"
+	target="_blank"
+	class="text-xl w-fit self-center rounded-md p-2 m-2 text-center text-secondary bg-primary"
 	>Open in immich</a
-> -->
+>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -6,8 +6,15 @@
 		id: string;
 	}
 	let { baseUrl, id }: Props = $props();
+
+	let imageUrl = $derived(baseUrl + '/photos/' + id);
 </script>
 
-<div class="border-8 border-white rounded-lg m-5 self-center">
-	<QrCode value={baseUrl + '/photos/' + id} />
+<div class="border-8 border-white rounded-lg self-center">
+	<QrCode value={imageUrl} />
 </div>
+<!-- <a
+	href={imageUrl}
+	class="text-xl border-gray-400 border-2 rounded-md p-2 m-2 text-center text-primary"
+	>Open in immich</a
+> -->

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import QrCode from 'svelte-qrcode';
+	import QrCode from '@castlenine/svelte-qrcode';
 
 	interface Props {
 		baseUrl: string;
@@ -7,11 +7,13 @@
 	}
 	let { baseUrl, id }: Props = $props();
 
-	let imageUrl = $derived(baseUrl + '/photos/' + id);
+	let imageUrl = `${baseUrl}/photos/${id}`;
 </script>
 
-<div class="border-8 border-white rounded-lg self-center">
-	<QrCode value={imageUrl} />
+<div
+	class="border-4 border-white rounded-lg self-center min-h-[128px] min-w-[128px] grow max-h-[200px] max-w-[200px] aspect-[1/1]"
+>
+	<QrCode data={imageUrl} isResponsive />
 </div>
 <a
 	href={imageUrl}

--- a/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
+++ b/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
@@ -1,30 +1,34 @@
 <script lang="ts">
-	import { createEventDispatcher } from 'svelte';
-	import { mdiChevronRight, mdiPlay, mdiPause, mdiChevronLeft } from '@mdi/js';
+	import {
+		mdiChevronRight,
+		mdiPlay,
+		mdiPause,
+		mdiChevronLeft,
+		mdiInformationOutline,
+		mdiInformationOffOutline
+	} from '@mdi/js';
 	import Icon from './icon.svelte';
 	import { ProgressBarStatus } from './progress-bar.svelte';
-
-	const dispatch = createEventDispatcher();
 
 	interface Props {
 		status: ProgressBarStatus;
 		overlayVisible: boolean;
+		infoVisible: boolean;
+		next: () => void;
+		back: () => void;
+		pause: () => void;
+		showInfo: () => void;
 	}
 
-	let { status = $bindable(), overlayVisible }: Props = $props();
-
-	function clickNext() {
-		dispatch('next');
-	}
-	function clickBack() {
-		dispatch('back');
-	}
-	function clickPause() {
-		dispatch('pause');
-	}
-	function clickSettings() {
-		// dispatch('settings');
-	}
+	let {
+		status = $bindable(),
+		overlayVisible,
+		infoVisible = $bindable(),
+		next,
+		back,
+		pause,
+		showInfo
+	}: Props = $props();
 
 	function shortcuts(node: any, shortcutList: any[]) {
 		function handleKeyDown(event: { key: any; preventDefault: () => void }) {
@@ -48,15 +52,19 @@
 	const shortcutList = [
 		{
 			key: 'ArrowRight',
-			action: clickNext
+			action: next
 		},
 		{
 			key: 'ArrowLeft',
-			action: clickBack
+			action: back
 		},
 		{
 			key: ' ',
-			action: clickPause
+			action: pause
+		},
+		{
+			key: 'i',
+			action: showInfo
 		}
 	];
 </script>
@@ -66,7 +74,7 @@
 {#if overlayVisible}
 	<div class="absolute h-full w-full top-0 left-0 z-[100] grid grid-cols-3 gap-2">
 		<div id="overlayback" class="group text-center content-center">
-			<button class="opacity-0 group-hover:opacity-100 text-primary" onclick={clickBack}
+			<button class="opacity-0 group-hover:opacity-100 text-primary" onclick={back}
 				><Icon
 					title="Back"
 					class="max-h-[min(10rem,33vh)] max-w-[min(10rem,33vh)] h-[33vh] w-[33vw]top"
@@ -77,12 +85,19 @@
 		</div>
 
 		<div class="grid grid-rows-3">
-			<div id="overlaysettings" class="group text-center content-center">
-				<!-- <button class="opacity-0 hover:opacity-100 text-primary" onclick={clickSettings}> </button> -->
+			<div id="overlayInfo" class="group text-center content-center">
+				<button class="opacity-0 hover:opacity-100 text-primary" onclick={showInfo}
+					><Icon
+						title="Info"
+						class="max-h-[min(10rem,33vh)] max-w-[min(10rem,33vh)] h-[33vh] w-[33vw]top"
+						path={infoVisible ? mdiInformationOffOutline : mdiInformationOutline}
+						size=""
+					/></button
+				>
 			</div>
 
 			<div id="overlaypause" class="group text-center content-center">
-				<button onclick={clickPause} class="opacity-0 group-hover:opacity-100 text-primary">
+				<button onclick={pause} class="opacity-0 group-hover:opacity-100 text-primary">
 					<Icon
 						class="max-h-[min(10rem,33vh)] max-w-[min(10rem,33vh)] h-[33vh] w-[33vw]"
 						title={status == ProgressBarStatus.Paused ? 'Play' : 'Pause'}
@@ -98,7 +113,7 @@
 		</div>
 
 		<div id="overlaynext" class="group text-center content-center">
-			<button class="opacity-0 group-hover:opacity-100 text-primary" onclick={clickNext}
+			<button class="opacity-0 group-hover:opacity-100 text-primary" onclick={next}
 				><Icon
 					title="Next"
 					class="max-h-[min(10rem,33vh)] max-w-[min(10rem,33vh)] h-[33vh] w-[33vw]top"

--- a/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
+++ b/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
@@ -72,7 +72,11 @@
 <svelte:window use:shortcuts={shortcutList} />
 
 {#if overlayVisible}
-	<div class="absolute h-full w-full top-0 left-0 z-[100] grid grid-cols-3 gap-2">
+	<div
+		class="absolute h-full w-full top-0 left-0 z-[100] grid grid-cols-3 gap-2 {infoVisible
+			? 'hidden'
+			: ''}"
+	>
 		<div id="overlayback" class="group text-center content-center">
 			<button class="opacity-0 group-hover:opacity-100 text-primary" onclick={back}
 				><Icon

--- a/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
+++ b/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
@@ -4,8 +4,7 @@
 		mdiPlay,
 		mdiPause,
 		mdiChevronLeft,
-		mdiInformationOutline,
-		mdiInformationOffOutline
+		mdiInformationOutline
 	} from '@mdi/js';
 	import Icon from './icon.svelte';
 	import { ProgressBarStatus } from './progress-bar.svelte';
@@ -94,7 +93,7 @@
 					><Icon
 						title="Info"
 						class="max-h-[min(10rem,33vh)] max-w-[min(10rem,33vh)] h-[33vh] w-[33vw]top"
-						path={infoVisible ? mdiInformationOffOutline : mdiInformationOutline}
+						path={mdiInformationOutline}
 						size=""
 					/></button
 				>

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -59,7 +59,7 @@
 	let unsubscribeStop: () => void;
 
 	let cursorVisible = $state(true);
-	let timeoutId: number;
+	let timeoutId: NodeJS.Timeout;
 
 	const clientIdentifier = $page.url.searchParams.get('client');
 	const authsecret = $page.url.searchParams.get('authsecret');

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -40,6 +40,7 @@
 	let progressBar: ProgressBar = $state() as ProgressBar;
 
 	let error: boolean = $state(false);
+	let infoVisible: boolean = $state(false);
 	let authError: boolean = $state(false);
 	let errorMessage: string = $state() as string;
 	let imagesState: ImagesState = $state({
@@ -347,6 +348,7 @@
 				{...imagesState}
 				imageFill={$configStore.imageFill}
 				imageZoom={$configStore.imageZoom}
+				bind:showInfo={infoVisible}
 			/>
 		</div>
 
@@ -357,20 +359,33 @@
 		<Appointments />
 
 		<OverlayControls
-			on:next={async () => {
+			next={async () => {
 				await handleDone(false, true);
+				infoVisible = false;
 			}}
-			on:back={async () => {
+			back={async () => {
 				await handleDone(true, true);
+				infoVisible = false;
 			}}
-			on:pause={async () => {
+			pause={async () => {
+				infoVisible = false;
 				if (progressBarStatus == ProgressBarStatus.Paused) {
 					await progressBar.play();
 				} else {
 					await progressBar.pause();
 				}
 			}}
+			showInfo={async () => {
+				if (infoVisible) {
+					infoVisible = false;
+					await progressBar.play();
+				} else {
+					infoVisible = true;
+					await progressBar.pause();
+				}
+			}}
 			bind:status={progressBarStatus}
+			bind:infoVisible
 			overlayVisible={cursorVisible}
 		/>
 

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -14,7 +14,7 @@
 	import Clock from '../elements/clock.svelte';
 	import Appointments from '../elements/appointments.svelte';
 	import LoadingElement from '../elements/LoadingElement.svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 
 	interface ImagesState {
 		images: [string, api.AssetResponseDto, api.AlbumResponseDto[]][];
@@ -61,8 +61,8 @@
 	let cursorVisible = $state(true);
 	let timeoutId: NodeJS.Timeout;
 
-	const clientIdentifier = $page.url.searchParams.get('client');
-	const authsecret = $page.url.searchParams.get('authsecret');
+	const clientIdentifier = page.url.searchParams.get('client');
+	const authsecret = page.url.searchParams.get('authsecret');
 
 	if (clientIdentifier && clientIdentifier != $clientIdentifierStore) {
 		clientIdentifierStore.set(clientIdentifier);

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -6,7 +6,7 @@
 	} from '$lib/components/elements/progress-bar.svelte';
 	import { slideshowStore } from '$lib/stores/slideshow.store';
 	import { clientIdentifierStore, authSecretStore } from '$lib/stores/persist.store';
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy, onMount, setContext } from 'svelte';
 	import OverlayControls from '../elements/overlay-controls.svelte';
 	import ImageComponent from '../elements/image-component.svelte';
 	import { configStore } from '$lib/stores/config.store';
@@ -76,6 +76,13 @@
 	const hideCursor = () => {
 		cursorVisible = false;
 	};
+
+	setContext('close', provideClose);
+
+	async function provideClose() {
+		infoVisible = false;
+		await progressBar.play();
+	}
 
 	const showCursor = () => {
 		cursorVisible = true;

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -183,6 +183,7 @@ export type IAppointment = {
     location?: string | null;
 };
 export type WebClientSettings = {
+    immichServerUrl?: string | null;
     margin?: string | null;
     interval?: number;
     transitionDuration?: number;


### PR DESCRIPTION
- Basic implementation of a 'more details'/'info' page
- QR-Code takes the base URL from the existing `ImmichServerUrl`
- Image overlay hides the action overlay (<, | |, >)
- Can be closed via the 'x' top right
- Shortcut 'i' to open/close the info overlay

To-do: Implement in client? (Shortcut and for android TV remotes) (cc @3rob3 )

Closes #242
