### PR TITLE
Maintenance: Add GitHub workflow to run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+    - name: Run tests
+      run: dotnet test ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj


### PR DESCRIPTION
Just runs the unit tests. They currently only test loading config versions, but more can be added over time.