### PR TITLE
Restrict authenticationSecret from being serialised in API

### DIFF
--- a/ImmichFrame.Core/Logic/AccountSelection/TotalAccountImagesSelectionStrategy.cs
+++ b/ImmichFrame.Core/Logic/AccountSelection/TotalAccountImagesSelectionStrategy.cs
@@ -1,10 +1,11 @@
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
+using Microsoft.Extensions.Logging;
 
 namespace ImmichFrame.Core.Logic.AccountSelection;
 
-public class TotalAccountImagesSelectionStrategy(IAssetAccountTracker _tracker) : IAccountSelectionStrategy
+public class TotalAccountImagesSelectionStrategy(ILogger<TotalAccountImagesSelectionStrategy> _logger, IAssetAccountTracker _tracker) : IAccountSelectionStrategy
 {
     private IList<IImmichFrameLogic> _accounts;
 
@@ -16,15 +17,16 @@ public class TotalAccountImagesSelectionStrategy(IAssetAccountTracker _tracker) 
     public async Task<AssetResponseDto?> GetNextAsset()
     {
         var chosen = await _accounts.ChooseOne(logic => logic.GetTotalAssets());
-
-
+        
         var asset = await chosen.GetNextAsset();
         if (asset != null)
         {
+            _logger.LogDebug("Returning next asset {id}", asset.Id);
             await _tracker.RecordAssetLocation(chosen, asset.Id);
             return asset;
         }
-
+        
+        _logger.LogDebug("No next asset found");
         return null;
     }
 
@@ -37,6 +39,7 @@ public class TotalAccountImagesSelectionStrategy(IAssetAccountTracker _tracker) 
     private async Task<IList<double>> GetProportions(IList<IImmichFrameLogic> accounts)
     {
         var (totals, sum) = await GetWeights(accounts);
+        _logger.LogDebug("Account [{}] will be split by proportion of {}", accounts, sum);
         return totals.Select(t => (double)t / sum).ToList();
     }
 
@@ -57,10 +60,14 @@ public class TotalAccountImagesSelectionStrategy(IAssetAccountTracker _tracker) 
             .Select(async tuple =>
             {
                 var (task, account, proportion) = tuple;
-                return (account, (await task).Shuffle().TakeProportional(proportion));
+                var assets = (await task).ToList();
+                _logger.LogDebug("Retrieved {total} asset(s) for account [{account}], will take {proportion}%", assets.Count(), account, proportion * 100);
+                return (account, assets.Shuffle().TakeProportional(proportion));
             });
 
         var accountAssetTupleList = await Task.WhenAll(taskList);
+
+        _logger.LogDebug("Processing {} list(s) of asset(s) of length {}", accountAssetTupleList.Length, string.Join(",", accountAssetTupleList.Select(a => a.Item2.Count())));
 
         foreach (var accountAssetTuple in accountAssetTupleList)
         {
@@ -70,7 +77,11 @@ public class TotalAccountImagesSelectionStrategy(IAssetAccountTracker _tracker) 
             }
         }
 
-        return accountAssetTupleList.SelectMany(tuple => tuple.Item2);
+        var assets = accountAssetTupleList.SelectMany(tuple => tuple.Item2).ToList();
+
+        _logger.LogDebug("Returning {count} asset(s)", assets.Count);
+
+        return assets;
     }
 
     public T ForAsset<T>(Guid assetId, Func<IImmichFrameLogic, T> f)

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -123,7 +123,8 @@ public class PooledImmichFrameLogic : IImmichFrameLogic
         return (fileName, contentType, data.Stream);
     }
 
-
     public Task SendWebhookNotification(IWebhookNotification notification) =>
         WebhookHelper.SendWebhookNotification(notification, _generalSettings.Webhook);
+
+    public override string ToString() => $"Account Pool [{_immichApi.BaseUrl}]";
 }

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -3,6 +3,7 @@ using ImmichFrame.Core.Interfaces;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authentication;
 using System.Reflection;
+using System.Text.Json.Serialization.Metadata;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
 using ImmichFrame.WebApi.Helpers;
@@ -62,7 +63,7 @@ builder.Services.AddSingleton<IAccountSelectionStrategy, TotalAccountImagesSelec
 builder.Services.AddTransient<Func<IAccountSettings, IImmichFrameLogic>>(srv => account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
 builder.Services.AddSingleton<IImmichFrameLogic, MultiImmichFrameLogicDelegate>();
 
-builder.Services.AddControllers();
+builder.Services.AddControllers().AddJsonOptions(options => { options.JsonSerializerOptions.TypeInfoResolver = IGeneralSettings.TypeInfoResolver; });
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();


### PR DESCRIPTION
Added a custom type resolver to omit the AuthenticationSecret field when an IGeneralSettings is being serialised by ASP.NET.

This works for a single omission like this, but I would recommend creating DTO types if there is any more divergence.