### PR TITLE
Added ClientSettingsDto to expose subset of general settings in API

### DIFF
--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -1,4 +1,5 @@
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ImmichFrame.WebApi.Controllers
@@ -17,11 +18,11 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetConfig")]
-        public IGeneralSettings GetConfig(string clientIdentifier = "")
+        public ClientSettingsDto GetConfig(string clientIdentifier = "")
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Config requested by '{sanitizedClientIdentifier}'", sanitizedClientIdentifier);
-            return _settings;
+            return ClientSettingsDto.FromGeneralSettings(_settings);
         }
 
         [HttpGet("Version", Name = "GetVersion")]

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -1,0 +1,61 @@
+using ImmichFrame.Core.Interfaces;
+
+namespace ImmichFrame.WebApi.Models;
+
+public class ClientSettingsDto
+{
+    public string Margin { get; set; }
+    public int Interval { get; set; }
+    public double TransitionDuration { get; set; }
+    public bool DownloadImages { get; set; }
+    public int RenewImagesDuration { get; set; }
+    public bool ShowClock { get; set; }
+    public string? ClockFormat { get; set; }
+    public bool ShowPhotoDate { get; set; }
+    public string? PhotoDateFormat { get; set; }
+    public bool ShowImageDesc { get; set; }
+    public bool ShowPeopleDesc { get; set; }
+    public bool ShowAlbumName { get; set; }
+    public bool ShowImageLocation { get; set; }
+    public string? ImageLocationFormat { get; set; }
+    public string? PrimaryColor { get; set; }
+    public string? SecondaryColor { get; set; }
+    public string Style { get; set; }
+    public string? BaseFontSize { get; set; }
+    public bool ShowWeatherDescription { get; set; }
+    public bool UnattendedMode { get; set; }
+    public bool ImageZoom { get; set; }
+    public bool ImageFill { get; set; }
+    public string Layout { get; set; }
+    public string Language { get; set; }
+
+    public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings)
+    {
+        ClientSettingsDto dto = new ClientSettingsDto();
+        dto.Margin = generalSettings.Margin;
+        dto.Interval = generalSettings.Interval;
+        dto.TransitionDuration = generalSettings.TransitionDuration;
+        dto.DownloadImages = generalSettings.DownloadImages;
+        dto.RenewImagesDuration = generalSettings.RenewImagesDuration;
+        dto.ShowClock = generalSettings.ShowClock;
+        dto.ClockFormat = generalSettings.ClockFormat;
+        dto.ShowPhotoDate = generalSettings.ShowPhotoDate;
+        dto.PhotoDateFormat = generalSettings.PhotoDateFormat;
+        dto.ShowImageDesc = generalSettings.ShowImageDesc;
+        dto.ShowPeopleDesc = generalSettings.ShowPeopleDesc;
+        dto.ShowAlbumName = generalSettings.ShowAlbumName;
+        dto.ShowImageLocation = generalSettings.ShowImageLocation;
+        dto.ImageLocationFormat = generalSettings.ImageLocationFormat;
+        dto.PrimaryColor = generalSettings.PrimaryColor;
+        dto.SecondaryColor = generalSettings.SecondaryColor;
+        dto.Style = generalSettings.Style;
+        dto.BaseFontSize = generalSettings.BaseFontSize;
+        dto.ShowWeatherDescription = generalSettings.ShowWeatherDescription;
+        dto.UnattendedMode = generalSettings.UnattendedMode;
+        dto.ImageZoom = generalSettings.ImageZoom;
+        dto.ImageFill = generalSettings.ImageFill;
+        dto.Layout = generalSettings.Layout;
+        dto.Language = generalSettings.Language;
+        return dto;
+    }
+}


### PR DESCRIPTION
Implemented ClientSettingsDto to provide subset of general settings to clients. Using a DTO means that further evolution of internal model won't change API. Note that `ImmichServerUrl` is omitted as there may now be multiple (and we previously confirmed that it was not used).