### PR TITLE
Chore: Switched to IMemoryCache to correctly handle expiration

### DIFF
--- a/ImmichFrame.Core.Tests/Logic/Pool/AlbumAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/AlbumAssetsPoolTests.cs
@@ -14,12 +14,12 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class AlbumAssetsPoolTests
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi;
     private Mock<IAccountSettings> _mockAccountSettings;
     private TestableAlbumAssetsPool _albumAssetsPool;
 
-    private class TestableAlbumAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+    private class TestableAlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
         : AlbumAssetsPool(apiCache, immichApi, accountSettings)
     {
         // Expose LoadAssets for testing
@@ -29,7 +29,7 @@ public class AlbumAssetsPoolTests
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(TimeSpan.MaxValue);
+        _mockApiCache = new Mock<IApiCache>();
         _mockImmichApi = new Mock<ImmichApi>("", null);
         _mockAccountSettings = new Mock<IAccountSettings>();
         _albumAssetsPool = new TestableAlbumAssetsPool(_mockApiCache.Object, _mockImmichApi.Object, _mockAccountSettings.Object);

--- a/ImmichFrame.Core.Tests/Logic/Pool/AllAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/AllAssetsPoolTests.cs
@@ -14,7 +14,7 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class AllAssetsPoolTests
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi;
     private Mock<IAccountSettings> _mockAccountSettings;
     private AllAssetsPool _allAssetsPool;
@@ -22,7 +22,7 @@ public class AllAssetsPoolTests
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(null);
+        _mockApiCache = new Mock<IApiCache>();
         _mockImmichApi = new Mock<ImmichApi>(null, null);
         _mockAccountSettings = new Mock<IAccountSettings>();
         _allAssetsPool = new AllAssetsPool(_mockApiCache.Object, _mockImmichApi.Object, _mockAccountSettings.Object);

--- a/ImmichFrame.Core.Tests/Logic/Pool/CachingApiAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/CachingApiAssetsPoolTests.cs
@@ -14,7 +14,7 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class CachingApiAssetsPoolTests
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi; // Dependency for constructor, may not be used directly in base class tests
     private Mock<IAccountSettings> _mockAccountSettings;
     private TestableCachingApiAssetsPool _testPool;
@@ -24,7 +24,7 @@ public class CachingApiAssetsPoolTests
     {
         public Func<Task<IEnumerable<AssetResponseDto>>> LoadAssetsFunc { get; set; }
 
-        public TestableCachingApiAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        public TestableCachingApiAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
             : base(apiCache, immichApi, accountSettings)
         {
         }
@@ -38,7 +38,7 @@ public class CachingApiAssetsPoolTests
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(null); // ILogger, IOptions<AppSettings>
+        _mockApiCache = new Mock<IApiCache>(); // ILogger, IOptions<AppSettings>
         _mockImmichApi = new Mock<ImmichApi>(null, null); // ILogger, IHttpClientFactory, IOptions<AppSettings>
         _mockAccountSettings = new Mock<IAccountSettings>();
 

--- a/ImmichFrame.Core.Tests/Logic/Pool/FavoriteAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/FavoriteAssetsPoolTests.cs
@@ -14,14 +14,14 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class FavoriteAssetsPoolTests
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi;
     private Mock<IAccountSettings> _mockAccountSettings; // Though not directly used by LoadAssets here
     private TestableFavoriteAssetsPool _favoriteAssetsPool;
 
     private class TestableFavoriteAssetsPool : FavoriteAssetsPool
     {
-        public TestableFavoriteAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        public TestableFavoriteAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
             : base(apiCache, immichApi, accountSettings) { }
 
         public Task<IEnumerable<AssetResponseDto>> TestLoadAssets(CancellationToken ct = default)
@@ -33,7 +33,7 @@ public class FavoriteAssetsPoolTests
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(null);
+        _mockApiCache = new Mock<IApiCache>();
         _mockImmichApi = new Mock<ImmichApi>(null, null);
         _mockAccountSettings = new Mock<IAccountSettings>();
         _favoriteAssetsPool = new TestableFavoriteAssetsPool(_mockApiCache.Object, _mockImmichApi.Object, _mockAccountSettings.Object);

--- a/ImmichFrame.Core.Tests/Logic/Pool/MemoryAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/MemoryAssetsPoolTests.cs
@@ -14,7 +14,7 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class MemoryAssetsPoolTests
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi;
     private Mock<IAccountSettings> _mockAccountSettings;
     private MemoryAssetsPool _memoryAssetsPool;
@@ -22,7 +22,7 @@ public class MemoryAssetsPoolTests
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(null); // Base constructor requires ILogger and IOptions, pass null for simplicity in mock
+        _mockApiCache = new Mock<IApiCache>(); // Base constructor requires ILogger and IOptions, pass null for simplicity in mock
         _mockImmichApi = new Mock<ImmichApi>(null, null); // Base constructor requires ILogger, IHttpClientFactory, IOptions, pass null
         _mockAccountSettings = new Mock<IAccountSettings>();
 
@@ -155,7 +155,7 @@ public class MemoryAssetsPoolTests
                 .ReturnsAsync(memories);
 
             // Reset and re-setup cache mock for each iteration to ensure factory is called
-            _mockApiCache = new Mock<ApiCache>(null);
+            _mockApiCache = new Mock<IApiCache>();
             _mockApiCache.Setup(c => c.GetOrAddAsync<IEnumerable<AssetResponseDto>>(It.IsAny<string>(), It.IsAny<Func<Task<IEnumerable<AssetResponseDto>>>>()))
                          .Returns<string, Func<Task<IEnumerable<AssetResponseDto>>>>(async (key, factory) => await factory());
             _memoryAssetsPool = new MemoryAssetsPool(_mockApiCache.Object, _mockImmichApi.Object, _mockAccountSettings.Object);

--- a/ImmichFrame.Core.Tests/Logic/Pool/PersonAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/PersonAssetsPoolTests.cs
@@ -14,14 +14,14 @@ namespace ImmichFrame.Core.Tests.Logic.Pool;
 [TestFixture]
 public class PersonAssetsPoolTests // Renamed from PeopleAssetsPoolTests to match class name
 {
-    private Mock<ApiCache> _mockApiCache;
+    private Mock<IApiCache> _mockApiCache;
     private Mock<ImmichApi> _mockImmichApi;
     private Mock<IAccountSettings> _mockAccountSettings;
     private TestablePersonAssetsPool _personAssetsPool;
 
     private class TestablePersonAssetsPool : PersonAssetsPool
     {
-        public TestablePersonAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
+        public TestablePersonAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings)
             : base(apiCache, immichApi, accountSettings) { }
 
         public Task<IEnumerable<AssetResponseDto>> TestLoadAssets(CancellationToken ct = default)
@@ -33,7 +33,7 @@ public class PersonAssetsPoolTests // Renamed from PeopleAssetsPoolTests to matc
     [SetUp]
     public void Setup()
     {
-        _mockApiCache = new Mock<ApiCache>(null);
+        _mockApiCache = new Mock<IApiCache>();
         _mockImmichApi = new Mock<ImmichApi>(null, null);
         _mockAccountSettings = new Mock<IAccountSettings>();
         _personAssetsPool = new TestablePersonAssetsPool(_mockApiCache.Object, _mockImmichApi.Object, _mockAccountSettings.Object);

--- a/ImmichFrame.Core/Interfaces/IApiCache.cs
+++ b/ImmichFrame.Core/Interfaces/IApiCache.cs
@@ -1,0 +1,4 @@
+public interface IApiCache
+{
+    Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory);
+}

--- a/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
@@ -4,7 +4,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class AlbumAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class AlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {

--- a/ImmichFrame.Core/Logic/Pool/AllAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AllAssetsPool.cs
@@ -3,7 +3,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class AllAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
+public class AllAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
 {
     public async Task<long> GetAssetCount(CancellationToken ct = default)
     {

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -3,7 +3,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public abstract class CachingApiAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
+public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
 {
     private readonly Random _random = new();
     

--- a/ImmichFrame.Core/Logic/Pool/FavoriteAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/FavoriteAssetsPool.cs
@@ -3,7 +3,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class FavoriteAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class FavoriteAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {

--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -3,7 +3,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class MemoryAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class MemoryAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {

--- a/ImmichFrame.Core/Logic/Pool/PeopleAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/PeopleAssetsPool.cs
@@ -3,7 +3,7 @@ using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
-public class PersonAssetsPool(ApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
+public class PersonAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : CachingApiAssetsPool(apiCache, immichApi, accountSettings)
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -9,7 +9,7 @@ namespace ImmichFrame.Core.Logic;
 public class PooledImmichFrameLogic : IImmichFrameLogic
 {
     private readonly IGeneralSettings _generalSettings;
-    private readonly ApiCache _apiCache;
+    private readonly IApiCache _apiCache;
     private readonly IAssetPool _pool;
     private readonly ImmichApi _immichApi;
     private readonly string _downloadLocation = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ImageCache");

--- a/ImmichFrame.Core/Services/IcalCalendarService.cs
+++ b/ImmichFrame.Core/Services/IcalCalendarService.cs
@@ -1,11 +1,12 @@
 using Ical.Net;
+using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.WebApi.Helpers;
 
 public class IcalCalendarService : ICalendarService
 {
     private readonly IGeneralSettings _serverSettings;
-    private readonly ApiCache _appointmentCache = new(TimeSpan.FromMinutes(15));
+    private readonly IApiCache _appointmentCache = new ApiCache(TimeSpan.FromMinutes(15));
 
     public IcalCalendarService(IGeneralSettings serverSettings)
     {

--- a/ImmichFrame.Core/Services/OpenWeatherMapService.cs
+++ b/ImmichFrame.Core/Services/OpenWeatherMapService.cs
@@ -4,7 +4,7 @@ using ImmichFrame.Core.Interfaces;
 public class OpenWeatherMapService : IWeatherService
 {
     private readonly IGeneralSettings _settings;
-    private readonly ApiCache _weatherCache = new(TimeSpan.FromMinutes(5));
+    private readonly IApiCache _weatherCache = new ApiCache(TimeSpan.FromMinutes(5));
     public OpenWeatherMapService(IGeneralSettings settings)
     {
         _settings = settings;


### PR DESCRIPTION
Switched out the IDictionary cache implementation to an IMemoryCache. 

This allows for proper expiration; the previous one relied on attempting to retrieve an entry to trigger expiration. This one will expire and remove entries asynchronously. It's also a Microsoft class so less code for us to maintain.

(We could probably remove the ApiCache entirely and just use IMemoryCache directly, however the former uses per-cache expiration settings, whereas the latter is per-entry, so is not a drop-in replacement.)