### PR TITLE
Added ImmichServerUrl to AssetResponseDto

### DIFF
--- a/ImmichFrame.Core/Api/AssetResponseDto.cs
+++ b/ImmichFrame.Core/Api/AssetResponseDto.cs
@@ -8,6 +8,8 @@ namespace ImmichFrame.Core.Api
     {
         [JsonIgnore]
         public Stream? ThumbhashImage => GetThumbHashStream();
+        
+        public string ImmichServerUrl { get; set; }
 
         private Stream? GetThumbHashStream()
         {

--- a/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
@@ -1,5 +1,6 @@
 ﻿using ImmichFrame.Core.Api;
 
+
 namespace ImmichFrame.Core.Interfaces
 {
     public interface IImmichFrameLogic
@@ -12,12 +13,18 @@ namespace ImmichFrame.Core.Interfaces
         public Task<long> GetTotalAssets();
         public Task SendWebhookNotification(IWebhookNotification notification);
     }
+
+    public interface IAccountImmichFrameLogic : IImmichFrameLogic
+    {
+        public IAccountSettings AccountSettings { get; }
+
+    }
     
     public interface IAccountSelectionStrategy
     {
-        void Initialize(IList<IImmichFrameLogic> accounts);
-        Task<AssetResponseDto?> GetNextAsset();
-        Task<IEnumerable<AssetResponseDto>> GetAssets();
-        T ForAsset<T>(Guid assetId, Func<IImmichFrameLogic, T> f);
+        void Initialize(IList<IAccountImmichFrameLogic> accounts);
+        Task<(IAccountImmichFrameLogic, AssetResponseDto)?> GetNextAsset();
+        Task<IEnumerable<(IAccountImmichFrameLogic, AssetResponseDto)>> GetAssets();
+        T ForAsset<T>(Guid assetId, Func<IAccountImmichFrameLogic, T> f);
     }
 }

--- a/ImmichFrame.Core/Logic/AccountSelection/BloomFilterAssetAccountTracker.cs
+++ b/ImmichFrame.Core/Logic/AccountSelection/BloomFilterAssetAccountTracker.cs
@@ -9,9 +9,9 @@ namespace ImmichFrame.Core.Logic.AccountSelection;
 
 public class BloomFilterAssetAccountTracker(ILogger<BloomFilterAssetAccountTracker> _logger) : IAssetAccountTracker
 {
-    private IDictionary<IImmichFrameLogic, IBloomFilter> logicToFilter = new Dictionary<IImmichFrameLogic, IBloomFilter>();
+    private IDictionary<IAccountImmichFrameLogic, IBloomFilter> logicToFilter = new Dictionary<IAccountImmichFrameLogic, IBloomFilter>();
 
-    public async ValueTask<bool> RecordAssetLocation(IImmichFrameLogic account, string assetId)
+    public async ValueTask<bool> RecordAssetLocation(IAccountImmichFrameLogic account, string assetId)
     {
         var filter = await logicToFilter.GetOrCreateAsync(account, NewFilter);
         return await filter.AddAsync(assetId);
@@ -22,7 +22,7 @@ public class BloomFilterAssetAccountTracker(ILogger<BloomFilterAssetAccountTrack
         return FilterBuilder.Build(await account.GetTotalAssets());
     }
 
-    public T ForAsset<T>(string assetId, Func<IImmichFrameLogic, T> f)
+    public T ForAsset<T>(string assetId, Func<IAccountImmichFrameLogic, T> f)
     {
         foreach (var entry in logicToFilter)
         {

--- a/ImmichFrame.Core/Logic/AccountSelection/IAssetAccountTracker.cs
+++ b/ImmichFrame.Core/Logic/AccountSelection/IAssetAccountTracker.cs
@@ -4,6 +4,6 @@ namespace ImmichFrame.Core.Logic.AccountSelection;
 
 public interface IAssetAccountTracker
 {
-    ValueTask<bool> RecordAssetLocation(IImmichFrameLogic account, string assetId);
-    T ForAsset<T>(string assetId, Func<IImmichFrameLogic, T> f);
+    ValueTask<bool> RecordAssetLocation(IAccountImmichFrameLogic account, string assetId);
+    T ForAsset<T>(string assetId, Func<IAccountImmichFrameLogic, T> f);
 }

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -6,7 +6,7 @@ using ImmichFrame.Core.Logic.Pool;
 
 namespace ImmichFrame.Core.Logic;
 
-public class PooledImmichFrameLogic : IImmichFrameLogic
+public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 {
     private readonly IGeneralSettings _generalSettings;
     private readonly ApiCache _apiCache;
@@ -19,11 +19,15 @@ public class PooledImmichFrameLogic : IImmichFrameLogic
         _generalSettings = generalSettings;
 
         var httpClient = new HttpClient();
+
+        AccountSettings = accountSettings;
         httpClient.UseApiKey(accountSettings.ApiKey);
         _immichApi = new ImmichApi(accountSettings.ImmichServerUrl, httpClient);
         _apiCache = new ApiCache(TimeSpan.FromHours(generalSettings.RefreshAlbumPeopleInterval));
         _pool = BuildPool(accountSettings);
     }
+
+    public IAccountSettings AccountSettings { get; }
 
     private IAssetPool BuildPool(IAccountSettings accountSettings)
     {

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -59,7 +59,7 @@ builder.Services.AddSingleton<IWeatherService, OpenWeatherMapService>();
 builder.Services.AddSingleton<ICalendarService, IcalCalendarService>();
 builder.Services.AddSingleton<IAssetAccountTracker, BloomFilterAssetAccountTracker>();
 builder.Services.AddSingleton<IAccountSelectionStrategy, TotalAccountImagesSelectionStrategy>();
-builder.Services.AddTransient<Func<IAccountSettings, IImmichFrameLogic>>(srv => account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
+builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(srv => account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
 builder.Services.AddSingleton<IImmichFrameLogic, MultiImmichFrameLogicDelegate>();
 
 builder.Services.AddControllers();

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -83,8 +83,7 @@
 				{/if}
 			</div>
 
-			<!-- TODO: Fix -->
-			<OverlayQr baseUrl={''} id={asset.id} />
+			<OverlayQr baseUrl={asset.ImmichServerUrl ?? ''} id={asset.id} />
 		</div>
 	</div>
 </div>

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/image-overlay.svelte
@@ -83,7 +83,7 @@
 				{/if}
 			</div>
 
-			<OverlayQr baseUrl={asset.ImmichServerUrl ?? ''} id={asset.id} />
+			<OverlayQr baseUrl={asset.immichServerUrl ?? ''} id={asset.id} />
 		</div>
 	</div>
 </div>

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -103,6 +103,7 @@ export type TagResponseDto = {
 export type AssetTypeEnum = 0 | 1 | 2 | 3;
 export type AssetVisibility = 0 | 1 | 2 | 3;
 export type AssetResponseDto = {
+    ImmichServerUrl?: string | null;
     checksum: string;
     deviceAssetId: string;
     deviceId: string;

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -103,7 +103,7 @@ export type TagResponseDto = {
 export type AssetTypeEnum = 0 | 1 | 2 | 3;
 export type AssetVisibility = 0 | 1 | 2 | 3;
 export type AssetResponseDto = {
-    ImmichServerUrl?: string | null;
+    immichServerUrl?: string | null;
     checksum: string;
     deviceAssetId: string;
     deviceId: string;


### PR DESCRIPTION
This is an alternative fix for https://github.com/immichFrame/ImmichFrame/pull/416

It works a little differently; the ImmichServerUrl is appended to the DTO by the class that is selecting across accounts, rather than the source pool. This allows future pool implementations not to care about the Url as it's appended later.