### PR TITLE
Feat: Add AssetController test with direct settings DI

### DIFF
--- a/ImmichFrame.Core/ImmichFrame.Core.csproj
+++ b/ImmichFrame.Core/ImmichFrame.Core.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NSwag.ApiDescription.Client" Version="13.18.2">
       <PrivateAssets>all</PrivateAssets>

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -14,19 +14,20 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
     private readonly ImmichApi _immichApi;
     private readonly string _downloadLocation = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ImageCache");
 
-    public PooledImmichFrameLogic(IAccountSettings accountSettings, IGeneralSettings generalSettings)
+    public PooledImmichFrameLogic(IAccountSettings accountSettings, IGeneralSettings generalSettings, IHttpClientFactory httpClientFactory)
     {
         _generalSettings = generalSettings;
 
-        var httpClient = new HttpClient();
-
+        var httpClient = httpClientFactory.CreateClient("ImmichApiAccountClient");
         AccountSettings = accountSettings;
+
         httpClient.UseApiKey(accountSettings.ApiKey);
         _immichApi = new ImmichApi(accountSettings.ImmichServerUrl, httpClient);
+
         _apiCache = new ApiCache(TimeSpan.FromHours(generalSettings.RefreshAlbumPeopleInterval));
         _pool = BuildPool(accountSettings);
     }
-
+    
     public IAccountSettings AccountSettings { get; }
 
     private IAssetPool BuildPool(IAccountSettings accountSettings)

--- a/ImmichFrame.WebApi.Tests/Controllers/AssetControllerTests.cs
+++ b/ImmichFrame.WebApi.Tests/Controllers/AssetControllerTests.cs
@@ -1,0 +1,188 @@
+using System.Net;
+using System.Net.Http;
+using ImmichFrame.WebApi.Tests.Mocks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http; // Added this
+using Moq;
+using Moq.Protected;
+using ImmichFrame.Core.Api;
+using ImmichFrame.WebApi.Models;
+using ImmichFrame.Core.Interfaces; // Added this back
+using NUnit.Framework;
+
+namespace ImmichFrame.WebApi.Tests.Controllers
+{
+    [TestFixture]
+    public class AssetControllerTests
+    {
+        private WebApplicationFactory<Program> _factory;
+        private Mock<HttpMessageHandler> _mockHttpMessageHandler;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            _factory = new WebApplicationFactory<Program>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureTestServices(services =>
+                    {
+                        // 1. Mock HttpMessageHandler and IHttpClientFactory
+                        services.AddSingleton<HttpMessageHandler>(_mockHttpMessageHandler.Object);
+                        services.AddHttpClient("ImmichApiAccountClient")
+                            .ConfigurePrimaryHttpMessageHandler(sp => sp.GetRequiredService<HttpMessageHandler>());
+                        services.ConfigureAll<HttpClientFactoryOptions>(options =>
+                        {
+                            options.HttpMessageHandlerBuilderActions.Add(b =>
+                            {
+                                b.PrimaryHandler = b.Services.GetRequiredService<HttpMessageHandler>();
+                            });
+                        });
+
+                        // 2. Directly instantiate and register settings objects
+                        var generalSettings = new GeneralSettings
+                        {
+                            ShowWeatherDescription = false, // Assuming this corresponds to ShowWeather
+                            ShowClock = true,
+                            ClockFormat = "HH:mm",
+                            Language = "en",
+                            PhotoDateFormat = "MM/dd/yyyy", // Crucial for the NRE
+                            ImageLocationFormat = "City,State,Country",
+                            DownloadImages = false,
+                            RenewImagesDuration = 30,
+                            // Ensure all non-nullable string properties that might be used have defaults if not set here
+                            PrimaryColor = "#FFFFFF", // Example default
+                            SecondaryColor = "#000000", // Example default
+                            Style = "none",
+                            BaseFontSize = "16px",
+                            WeatherApiKey = "",
+                            UnitSystem = "imperial",
+                            WeatherLatLong = "0,0"
+                        };
+
+                        var accountSettings = new ServerAccountSettings
+                        {
+                            ImmichServerUrl = "http://mock-immich-server.com",
+                            ApiKey = "test-api-key",
+                            ShowMemories = false,
+                            ShowFavorites = true,
+                            ShowArchived = false,
+                            Albums = new List<Guid>(),
+                            ExcludedAlbums = new List<Guid>(),
+                            People = new List<Guid>()
+                        };
+
+                        var serverSettings = new ServerSettings
+                        {
+                            GeneralSettingsImpl = generalSettings,
+                            AccountsImpl = new List<ServerAccountSettings> { accountSettings }
+                        };
+
+                        services.AddSingleton<IServerSettings>(serverSettings);
+                        services.AddSingleton<IGeneralSettings>(generalSettings);
+                        // Ensure IAccountSettings can be resolved if needed by MultiImmichFrameLogicDelegate directly
+                        // However, PooledImmichFrameLogic receives IAccountSettings via the factory Func
+                    });
+                });
+        }
+
+        // Removed OneTimeSetup that created Settings.json
+
+        [TearDown]
+        public void TearDown()
+        {
+            _factory.Dispose();
+        }
+
+        [Test]
+        public async Task GetRandomImage_ReturnsImageFromMockServer()
+        {
+            // Arrange
+            var expectedAssetId = Guid.NewGuid();
+            var assetDtoJson = $@"
+            {{
+                ""id"": ""{expectedAssetId}"",
+                ""originalPath"": ""/path/to/image.jpg"",
+                ""type"": ""IMAGE"",
+                ""fileCreatedAt"": ""2023-10-26T10:00:00Z"",
+                ""fileModifiedAt"": ""2023-10-26T10:00:00Z"",
+                ""isFavorite"": true,
+                ""duration"": ""0:00:00"",
+                ""checksum"": ""testchecksum"",
+                ""deviceAssetId"": ""testDeviceAssetId"",
+                ""deviceId"": ""testDeviceId"",
+                ""ownerId"": ""testOwnerId"",
+                ""originalFileName"": ""image.jpg"",
+                ""localDateTime"": ""2023-10-26T10:00:00Z"",
+                ""visibility"": ""timeline"",
+                ""hasMetadata"": true,
+                ""isArchived"": false,
+                ""isOffline"": false,
+                ""isTrashed"": false,
+                ""thumbhash"": ""I0cMCQS94XmImZeXmYd3d3g="",
+                ""updatedAt"": ""2023-10-26T10:00:00Z""
+            }}";
+
+            // JSON structure for SearchResponseDto
+            var jsonResponse = $@"
+            {{
+                ""albums"": {{
+                    ""count"": 0,
+                    ""items"": [],
+                    ""total"": 0,
+                    ""facets"": []
+                }},
+                ""assets"": {{
+                    ""count"": 1,
+                    ""items"": [
+                        {assetDtoJson}
+                    ],
+                    ""total"": 1,
+                    ""facets"": [],
+                    ""nextPage"": null
+                }}
+            }}";
+
+            // Setup for SearchAssetsAsync
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/search/metadata")),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(() => new HttpResponseMessage // Use a Func to return new instance each time
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(jsonResponse)
+                });
+
+            // Setup for ViewAssetAsync (thumbnail)
+            var mockImageData = new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }; // Minimal JPEG
+            _mockHttpMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(req => req.RequestUri!.ToString().Contains("/thumbnail")),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(() => new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new ByteArrayContent(mockImageData)
+                });
+
+            var client = _factory.CreateClient();
+
+            // Act
+            var response = await client.GetAsync("/api/Asset/RandomImageAndInfo");
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+            var content = await response.Content.ReadAsStringAsync();
+            // For now, we'll just check if the response is not empty.
+            // A more robust check would be to deserialize the response and check the asset ID.
+            Assert.That(content, Is.Not.Empty);
+        }
+    }
+}

--- a/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
+++ b/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AwesomeAssertions" Version="9.0.0" /><PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="AwesomeAssertions" Version="9.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
       <PackageReference Include="Moq" Version="4.20.70" />

--- a/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
+++ b/ImmichFrame.WebApi.Tests/ImmichFrame.WebApi.Tests.csproj
@@ -1,28 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AwesomeAssertions" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="AwesomeAssertions" Version="9.0.0" /><PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+      <PackageReference Include="Moq" Version="4.20.70" />
+      <PackageReference Include="NUnit" Version="4.3.2" />
+      <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+      <PackageReference Include="NUnit.Analyzers" Version="4.2.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="coverlet.collector" Version="6.0.2">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ImmichFrame.WebApi\ImmichFrame.WebApi.csproj" />

--- a/ImmichFrame.WebApi.Tests/Mocks/MockHttpMessageHandler.cs
+++ b/ImmichFrame.WebApi.Tests/Mocks/MockHttpMessageHandler.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ImmichFrame.WebApi.Tests.Mocks
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string responseContent, HttpStatusCode statusCode)
+        {
+            _responseContent = responseContent;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage
+            {
+                StatusCode = _statusCode,
+                Content = new StringContent(_responseContent)
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -105,9 +105,9 @@ namespace ImmichFrame.WebApi.Controllers
 
             var locationFormat = _settings.ImageLocationFormat ?? "City,State,Country";
             var imageLocation = locationFormat
-                .Replace("City", randomImage.ExifInfo.City ?? string.Empty)
-                .Replace("State", randomImage.ExifInfo.State ?? string.Empty)
-                .Replace("Country", randomImage.ExifInfo.Country ?? string.Empty);
+                .Replace("City", randomImage.ExifInfo?.City ?? string.Empty)
+                .Replace("State", randomImage.ExifInfo?.State ?? string.Empty)
+                .Replace("Country", randomImage.ExifInfo?.Country ?? string.Empty);
             imageLocation = string.Join(",", imageLocation.Split(',').Where(s => !string.IsNullOrWhiteSpace(s)));
 
             return new ImageResponse

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Authentication;
 using System.Reflection;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
-using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Helpers.Config;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -59,7 +58,11 @@ builder.Services.AddSingleton<IWeatherService, OpenWeatherMapService>();
 builder.Services.AddSingleton<ICalendarService, IcalCalendarService>();
 builder.Services.AddSingleton<IAssetAccountTracker, BloomFilterAssetAccountTracker>();
 builder.Services.AddSingleton<IAccountSelectionStrategy, TotalAccountImagesSelectionStrategy>();
-builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(srv => account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
+builder.Services.AddHttpClient(); // Ensures IHttpClientFactory is available
+
+builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(srv =>
+    account => ActivatorUtilities.CreateInstance<PooledImmichFrameLogic>(srv, account));
+
 builder.Services.AddSingleton<IImmichFrameLogic, MultiImmichFrameLogicDelegate>();
 
 builder.Services.AddControllers();
@@ -107,3 +110,6 @@ app.MapControllers();
 app.MapFallbackToFile("/index.html");
 
 app.Run();
+
+// Make Program public for WebApplicationFactory
+public partial class Program { }


### PR DESCRIPTION
This performs a test calling through to a mock immich API. Provides a fast sanity test to ensure that data is being passed through the system plus a base to add more service-level testing if we need it.