### PR TITLE
Allow overlays to be moved

### DIFF
--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -55,5 +55,8 @@
         public bool ImageFill { get; }
         public string Layout { get; }
         public string Language { get; }
+        public string ClockPosition { get; }
+        public string AssetInfoPosition { get; }
+        public string AppointmentsPosition { get; }
     }
 }

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -111,5 +111,8 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ImageFill => _delegate.ImageFill;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
+        public string ClockPosition => "bottom-left";
+        public string AssetInfoPosition => "bottom-right";
+        public string AppointmentsPosition => "top-right";
     }
 }

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -50,6 +50,9 @@ public class ServerSettingsV1 : IConfigSettable
     public bool ImagePan { get; set; } = false;
     public bool ImageFill { get; set; } = false;
     public string Layout { get; set; } = "splitview";
+    public string ClockPosition { get; set; } = "bottom-left";
+    public string AssetInfoPosition { get; set; } = "bottom-right";
+    public string AppointmentsPosition { get; set; } = "top-right";
 }
 
 /// <summary>
@@ -111,8 +114,8 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ImageFill => _delegate.ImageFill;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
-        public string ClockPosition => "bottom-left";
-        public string AssetInfoPosition => "bottom-right";
-        public string AppointmentsPosition => "top-right";
+        public string ClockPosition => _delegate.ClockPosition;
+        public string AssetInfoPosition => _delegate.AssetInfoPosition;
+        public string AppointmentsPosition => _delegate.AppointmentsPosition;
     }
 }

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -28,6 +28,9 @@ public class ClientSettingsDto
     public bool ImageFill { get; set; }
     public string Layout { get; set; }
     public string Language { get; set; }
+    public string ClockPosition { get; set; }
+    public string AssetInfoPosition { get; set; }
+    public string AppointmentsPosition { get; set; }
 
     public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings)
     {
@@ -56,6 +59,9 @@ public class ClientSettingsDto
         dto.ImageFill = generalSettings.ImageFill;
         dto.Layout = generalSettings.Layout;
         dto.Language = generalSettings.Language;
+        dto.ClockPosition = generalSettings.ClockPosition;
+        dto.AssetInfoPosition = generalSettings.AssetInfoPosition;
+        dto.AppointmentsPosition = generalSettings.AppointmentsPosition;
         return dto;
     }
 }

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -58,6 +58,9 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string? WeatherLatLong { get; set; } = "40.7128,74.0060";
     public string? Webhook { get; set; }
     public string? AuthenticationSecret { get; set; }
+    public string ClockPosition { get; set; } = "bottom-left";
+    public string AssetInfoPosition { get; set; } = "bottom-right";
+    public string AppointmentsPosition { get; set; } = "top-right";
 }
 
 public class ServerAccountSettings : IAccountSettings, IConfigSettable

--- a/docker/Settings.example.json
+++ b/docker/Settings.example.json
@@ -32,7 +32,10 @@
     "ImageZoom": true,
     "ImagePan": false,
     "ImageFill": false,
-    "Layout": "splitview"
+    "Layout": "splitview",
+    "ClockPosition": "bottom-left",
+    "AssetInfoPosition": "bottom-right",
+    "AppointmentsPosition": "top-right"
   },
   "Accounts": [
     {

--- a/docker/Settings.example.yml
+++ b/docker/Settings.example.yml
@@ -31,6 +31,9 @@ General:
   ImagePan: false
   ImageFill: false
   Layout: splitview
+  ClockPosition: bottom-left
+  AssetInfoPosition: bottom-right
+  AppointmentsPosition: top-right
 Accounts:
   - ImmichServerUrl: REQUIRED
     ApiKey: REQUIRED

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -49,6 +49,8 @@ General:
   ShowClock: true  # boolean
   # Time format
   ClockFormat: 'hh:mm'  # string
+  # Position of the clock overlay (format: vertical-horizontal)
+  ClockPosition: 'bottom-left'  # 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'
   # Displays the progress bar.
   ShowProgressBar: true  # boolean
   # Displays the date of the current image.
@@ -61,6 +63,10 @@ General:
   ShowAlbumName: true  # boolean
   # Displays the location of the current image.
   ShowImageLocation: true  # boolean
+  # Position of the asset info overlay (photo date, description, people, albums, location)
+  AssetInfoPosition: 'bottom-right'  # 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'
+  # Position of the appointments overlay
+  AppointmentsPosition: 'top-right'  # 'top-left' | 'top-center' | 'top-right' | 'bottom-left' | 'bottom-center' | 'bottom-right'
   # Lets you choose a primary color for your UI. Use hex with alpha value to edit opacity.
   PrimaryColor: '#f5deb3'  # string
   # Lets you choose a secondary color for your UI. (Only used with `style=solid or transition`) Use hex with alpha value to edit opacity.
@@ -124,6 +130,19 @@ Weather is enabled by entering an API key. Get yours free from [OpenWeatherMap][
 
 ### Calendar
 If you are using Google Calendar, more information can be found [here](https://support.google.com/calendar/answer/37648?hl=en#zippy=%2Cget-your-calendar-view-only).
+
+### Overlay Positioning
+You can customize the position of different overlays on the screen:
+
+- **ClockPosition**: Controls where the clock, date, and weather information appears
+- **AssetInfoPosition**: Controls where image metadata (date, description, people, albums, location) appears  
+- **AppointmentsPosition**: Controls where calendar appointments appear
+
+Each position setting uses the format `vertical-horizontal` with these options:
+- **Vertical**: `top` or `bottom`
+- **Horizontal**: `left`, `center`, or `right`
+
+For example: `top-left`, `bottom-center`, `top-right`, etc.
 
 ### Misc
 #### Webhook

--- a/immichFrame.Web/src/lib/components/elements/appointments.svelte
+++ b/immichFrame.Web/src/lib/components/elements/appointments.svelte
@@ -4,6 +4,7 @@
 	import { format } from 'date-fns';
 	import { configStore } from '$lib/stores/config.store';
 	import { clientIdentifierStore } from '$lib/stores/persist.store';
+	import { getPositionClasses, getTextAlignment } from '$lib/utils';
 
 	api.init();
 
@@ -51,7 +52,9 @@
 {#if appointments}
 	<div
 		id="appointments"
-		class="fixed top-0 right-0 w-auto z-10 text-center text-primary m-5 max-w-[20%] hidden lg:block md:min-w-[10%]"
+		class="fixed w-auto z-10 text-primary m-5 max-w-[20%] hidden lg:block md:min-w-[10%]
+		{getPositionClasses($configStore.appointmentsPosition || 'top-right')}
+		{getTextAlignment($configStore.appointmentsPosition || 'top-right')}"
 	>
 		<!-- <div class="text-4xl mx-8 font-bold">Appointments</div> -->
 		<div class="">

--- a/immichFrame.Web/src/lib/components/elements/asset-info.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset-info.svelte
@@ -5,6 +5,7 @@
 	import { configStore } from '$lib/stores/config.store';
 	import Icon from './icon.svelte';
 	import { mdiCalendar, mdiMapMarker, mdiAccount, mdiText, mdiImageAlbum } from '@mdi/js';
+	import { getPositionClasses, getTextAlignment } from '$lib/utils';
 
 	interface Props {
 		asset: AssetResponseDto;
@@ -68,7 +69,9 @@
 {#if showPhotoDate || showLocation || showImageDesc || showPeopleDesc || showAlbumName}
 	<div
 		id="imageinfo"
-		class="immichframe_image_metadata absolute bottom-0 right-0 z-100 text-primary p-1 text-right
+		class="immichframe_image_metadata absolute z-100 text-primary p-1
+		{getPositionClasses($configStore.assetInfoPosition || 'bottom-right')}
+		{getTextAlignment($configStore.assetInfoPosition || 'bottom-right')}
 		{$configStore.style == 'solid' ? 'bg-secondary rounded-tl-2xl' : ''}
 		{$configStore.style == 'transition' ? 'bg-gradient-to-l from-secondary from-0% pl-10' : ''}
 		{$configStore.style == 'blur' ? 'backdrop-blur-lg rounded-tl-2xl' : ''}	"

--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -5,6 +5,7 @@
 	import * as locale from 'date-fns/locale';
 	import { configStore } from '$lib/stores/config.store';
 	import { clientIdentifierStore } from '$lib/stores/persist.store';
+	import { getPositionClasses, getTextAlignment } from '$lib/utils';
 
 	api.init();
 
@@ -54,7 +55,9 @@
 
 <div
 	id="clock"
-	class="fixed bottom-0 left-0 z-10 text-center text-primary
+	class="fixed z-10 text-primary
+	{getPositionClasses($configStore.clockPosition || 'bottom-left')}
+	{getTextAlignment($configStore.clockPosition || 'bottom-left')}
 	{$configStore.style == 'solid' ? 'bg-secondary rounded-tr-2xl' : ''}
 	{$configStore.style == 'transition' ? 'bg-gradient-to-r from-secondary from-0% pr-10' : ''}
 	{$configStore.style == 'blur' ? 'backdrop-blur-lg rounded-tr-2xl' : ''}	

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
  * ImmichFrame.WebApi
  * 1.0
@@ -209,6 +208,9 @@ export type ClientSettingsDto = {
     imageFill?: boolean;
     layout?: string | null;
     language?: string | null;
+    clockPosition?: string | null;
+    assetInfoPosition?: string | null;
+    appointmentsPosition?: string | null;
 };
 export type IWeather = {
     location?: string | null;

--- a/immichFrame.Web/src/lib/utils.ts
+++ b/immichFrame.Web/src/lib/utils.ts
@@ -3,3 +3,36 @@ export const decodeBase64 = (data: string) => Uint8Array.from(atob(data), (c) =>
 export const handlePromiseError = <T>(promise: Promise<T>): void => {
 	promise.catch((error) => console.error(`[utils.ts]:handlePromiseError ${error}`, error));
 };
+
+export const getPositionClasses = (position: string): string => {
+	const [vertical, horizontal] = position.split('-');
+	
+	const verticalClass = vertical === 'top' ? 'top-0' : 'bottom-0';
+	
+	let horizontalClass = '';
+	switch (horizontal) {
+		case 'left':
+			horizontalClass = 'left-0';
+			break;
+		case 'center':
+			horizontalClass = 'left-1/2 transform -translate-x-1/2';
+			break;
+		case 'right':
+			horizontalClass = 'right-0';
+			break;
+		default:
+			horizontalClass = 'left-0';
+	}
+	
+	return `${verticalClass} ${horizontalClass}`;
+};
+
+export const getTextAlignment = (position: string): string => {
+	if (position.endsWith('-right')) {
+		return 'text-right';
+	} else if (position.endsWith('-center')) {
+		return 'text-center';
+	} else {
+		return 'text-left';
+	}
+};


### PR DESCRIPTION
One of the picture frames I maintain has limited line of sight to the bottom of the frame. I needed to be able to move all the overlays to the top. This feature allows repositioning of the main overlays in the project.

<img width="950" alt="image" src="https://github.com/user-attachments/assets/37348aa5-fa8b-490a-9f7f-028b580a20ec" />


Each option accepts a vertical position (top, bottom) and a horizontal position (left, center, right).

From the updated documentation:

### Overlay Positioning
You can customize the position of different overlays on the screen:

- **ClockPosition**: Controls where the clock, date, and weather information appears
- **AssetInfoPosition**: Controls where image metadata (date, description, people, albums, location) appears
- **AppointmentsPosition**: Controls where calendar appointments appear