### PR TITLE
docs: fix Desktop section level and move keyboard section to Android

### DIFF
--- a/docs/docs/getting-started/apps.md
+++ b/docs/docs/getting-started/apps.md
@@ -140,7 +140,15 @@ Follow instructions below to update WebView to 106. This has been tested and wor
   ```shell
   adb reboot
   ```
-### Desktop (Windows, MacOS, Linux)
+
+### Keyboard
+**Settings** - Up arrow  
+**Quit** - Down arrow  
+**Prev Image** - Left arrow  
+**Next Image** - Right arrow  
+**Pause** - Enter/Return  
+
+## Desktop (Windows, MacOS, Linux)
 
 Get the latest Desktop-App from the [GitHub Releases][releases-url]-Page.
 
@@ -158,14 +166,6 @@ The screen is configured in a 3x3 gird. You can touch or click:
   ```bash 
   xattr -c /Applications/immichframe.app
   ```
-
-## Keyboard
-**Settings** - Up arrow  
-**Quit** - Down arrow  
-**Prev Image** - Left arrow  
-**Next Image** - Right arrow  
-**Pause** - Enter/Return  
-
 
 <!-- MARKDOWN LINKS & IMAGES -->
 [play-store-link]: https://play.google.com/store/apps/details?id=com.immichframe.immichframe


### PR DESCRIPTION
The Desktop section was under the Android section.

But I moved the Keyboard section under Android because I could not find any keyboard handling in the Desktop app source code while the arrow keys are handled in the Android app here:

https://github.com/immichFrame/ImmichFrame_Android/blob/8eb0ac8a6e2e4b583eb58418fd2083b072329a9b/app/src/main/java/com/immichframe/immichframe/MainActivity.kt#L704-L737

But I could not find the Arrow Down handling to quit the application :(