### PR TITLE
Permit RefreshAlbumPeopleInterval of 0

### DIFF
--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -23,9 +23,12 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         AccountSettings = accountSettings;
         httpClient.UseApiKey(accountSettings.ApiKey);
         _immichApi = new ImmichApi(accountSettings.ImmichServerUrl, httpClient);
-        _apiCache = new ApiCache(TimeSpan.FromHours(generalSettings.RefreshAlbumPeopleInterval));
+        _apiCache = new ApiCache(RefreshInterval(generalSettings.RefreshAlbumPeopleInterval));
         _pool = BuildPool(accountSettings);
     }
+
+    private static TimeSpan RefreshInterval(int hours)
+        => hours > 0 ? TimeSpan.FromHours(hours) : TimeSpan.FromMilliseconds(1);
 
     public IAccountSettings AccountSettings { get; }
 


### PR DESCRIPTION
Allow RefreshAlbumPeopleInterval to be set to zero, which will set the cache timeout to 1ms (it cannot be set to TimeSpan.Zero).