### PR TITLE
Fix: Memories cache should last one day

### DIFF
--- a/ImmichFrame.Core/Helpers/ApiCache.cs
+++ b/ImmichFrame.Core/Helpers/ApiCache.cs
@@ -4,19 +4,23 @@ namespace ImmichFrame.Core.Helpers;
 
 public class ApiCache : IApiCache, IDisposable
 {
-    private readonly MemoryCacheEntryOptions _cacheOptions;
+    private readonly Func<MemoryCacheEntryOptions> _cacheOptions;
     private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
 
-    public ApiCache(TimeSpan cacheDuration)
+    public ApiCache(TimeSpan cacheDuration) : this(() => new MemoryCacheEntryOptions()
     {
-        _cacheOptions = new()
-        {
-            AbsoluteExpirationRelativeToNow = cacheDuration
-        };
+        AbsoluteExpirationRelativeToNow = cacheDuration
+    })
+    {
+    }
+
+    public ApiCache(Func<MemoryCacheEntryOptions> entryOptions)
+    {
+        _cacheOptions = entryOptions;
     }
 
     public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
-        => _cache.GetOrCreateAsync<T>(key, _ => factory(), _cacheOptions);
+        => _cache.GetOrCreateAsync<T>(key, _ => factory(), _cacheOptions());
 
     public void Dispose()
         => _cache.Dispose();

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -42,7 +42,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
             pools.Add(new FavoriteAssetsPool(_apiCache, _immichApi, accountSettings));
 
         if (accountSettings.ShowMemories)
-            pools.Add(new MemoryAssetsPool(_apiCache, _immichApi, accountSettings));
+            pools.Add(new MemoryAssetsPool(_immichApi, accountSettings));
 
         if (accountSettings.Albums.Any())
             pools.Add(new AlbumAssetsPool(_apiCache, _immichApi, accountSettings));


### PR DESCRIPTION
I noticed that the API caching is set to the same for all types of asset, however it should be fixed to one day for memories as they should be refreshed daily.