### PR TITLE
Creating new config property for clock date format (ClockDateFormat)

### DIFF
--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -37,6 +37,7 @@
         public int RenewImagesDuration { get; }
         public bool ShowClock { get; }
         public string? ClockFormat { get; }
+		public string? ClockDateFormat { get; }
         public bool ShowProgressBar { get; }
         public bool ShowPhotoDate { get; }
         public string? PhotoDateFormat { get; }

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -33,6 +33,7 @@ public class ServerSettingsV1 : IConfigSettable
     public double TransitionDuration { get; set; } = 1;
     public bool ShowClock { get; set; } = true;
     public string? ClockFormat { get; set; } = "hh:mm";
+	public string? ClockDateFormat { get; set; } = "MM/dd/yyyy";
     public bool ShowProgressBar { get; set; } = true;
     public bool ShowPhotoDate { get; set; } = true;
     public string? PhotoDateFormat { get; set; } = "MM/dd/yyyy";
@@ -93,6 +94,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public int RenewImagesDuration => _delegate.RenewImagesDuration;
         public bool ShowClock => _delegate.ShowClock;
         public string? ClockFormat => _delegate.ClockFormat;
+		public string? ClockDateFormat => _delegate.ClockDateFormat;
         public bool ShowProgressBar => _delegate.ShowProgressBar;
         public bool ShowPhotoDate => _delegate.ShowPhotoDate;
         public string? PhotoDateFormat => _delegate.PhotoDateFormat;

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -10,6 +10,7 @@ public class ClientSettingsDto
     public int RenewImagesDuration { get; set; }
     public bool ShowClock { get; set; }
     public string? ClockFormat { get; set; }
+	public string? ClockDateFormat {get; set; }
     public bool ShowPhotoDate { get; set; }
     public bool ShowProgressBar { get; set; }
     public string? PhotoDateFormat { get; set; }
@@ -38,6 +39,7 @@ public class ClientSettingsDto
         dto.RenewImagesDuration = generalSettings.RenewImagesDuration;
         dto.ShowClock = generalSettings.ShowClock;
         dto.ClockFormat = generalSettings.ClockFormat;
+		dto.ClockDateFormat = generalSettings.ClockDateFormat;
         dto.ShowPhotoDate = generalSettings.ShowPhotoDate;
         dto.ShowProgressBar = generalSettings.ShowProgressBar;
         dto.PhotoDateFormat = generalSettings.PhotoDateFormat;

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -35,6 +35,7 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public double TransitionDuration { get; set; } = 1;
     public bool ShowClock { get; set; } = true;
     public string? ClockFormat { get; set; } = "hh:mm";
+	public string? ClockDateFormat { get; set; } = "MM/dd/yyyy";
     public bool ShowProgressBar { get; set; } = true;
     public bool ShowPhotoDate { get; set; } = true;
     public bool ShowImageDesc { get; set; } = true;

--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -15,9 +15,9 @@
 	);
 
 	let now = $state(new Date());
-
+	
 	const formattedDate = $derived(() =>
-		format(now, $configStore.photoDateFormat ?? 'dd.MM.yyyy', {
+		format(now, $configStore.clockDateFormat ?? 'dd.MM.yyyy', {
 			locale: localeToUse()
 		})
 	);

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -192,6 +192,7 @@ export type ClientSettingsDto = {
     renewImagesDuration?: number;
     showClock?: boolean;
     clockFormat?: string | null;
+	clockDateFormat?: string | null;
     showPhotoDate?: boolean;
     showProgressBar?: boolean;
     photoDateFormat?: string | null;


### PR DESCRIPTION
I wanted to having the Date above the clock be in a separate format from the Photo Date so I created a new property in the Config for ClockDateFormat and altered the clock.svelte file to use the new ClockDateFormat as opposed to PhotoDateFormat.

This is my first time ever touching svelte or C# so mostly hacking around.  

Would love to know any tips for how to better help develop.