### PR TITLE
 Pull Request: Add Chronological Images Feature

### DIFF
--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -57,5 +57,7 @@
         public bool ImageFill { get; }
         public string Layout { get; }
         public string Language { get; }
+        public bool ShowChronologicalImages { get; }
+        public int ChronologicalImagesCount { get; }
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -12,12 +12,12 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
         return (await AllAssets(ct)).Count();
     }
     
-    public async Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default)
+    public virtual async Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default)
     {
         return (await AllAssets(ct)).OrderBy(_ => _random.Next()).Take(requested);
     }
 
-    private async Task<IEnumerable<AssetResponseDto>> AllAssets(CancellationToken ct = default)
+    protected async Task<IEnumerable<AssetResponseDto>> AllAssets(CancellationToken ct = default)
     {
         return await apiCache.GetOrAddAsync(GetType().FullName!, () => ApplyAccountFilters(LoadAssets(ct)));
     }

--- a/ImmichFrame.Core/Logic/Pool/ChronologicalAssetsPoolWrapper.cs
+++ b/ImmichFrame.Core/Logic/Pool/ChronologicalAssetsPoolWrapper.cs
@@ -1,0 +1,77 @@
+using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Interfaces;
+
+namespace ImmichFrame.Core.Logic.Pool;
+
+public class ChronologicalAssetsPoolWrapper(IAssetPool basePool, IGeneralSettings generalSettings) : IAssetPool
+{
+    private readonly Random _random = new();
+    
+    public Task<long> GetAssetCount(CancellationToken ct = default)
+    {
+        return basePool.GetAssetCount(ct);
+    }
+    
+    public async Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default)
+    {
+        if (!generalSettings.ShowChronologicalImages || generalSettings.ChronologicalImagesCount <= 0)
+        {
+            // Fallback to base pool behavior if chronological is disabled
+            return await basePool.GetAssets(requested, ct);
+        }
+        
+        var chronologicalCount = generalSettings.ChronologicalImagesCount;
+        
+        // Get a larger set to work with for chronological selection
+        var availableAssets = await basePool.GetAssets(Math.Max(requested * 10, 100), ct);
+        
+        // Create chronological sets and mix them randomly
+        var chronologicalSets = CreateChronologicalSets(availableAssets, chronologicalCount);
+        
+        // Shuffle the sets randomly but keep chronological order within each set
+        var shuffledSets = chronologicalSets.OrderBy(_ => _random.Next()).ToList();
+        
+        // Flatten the sets and take the requested amount
+        var result = shuffledSets
+            .SelectMany(set => set)
+            .Take(requested)
+            .ToList();
+        
+        return result;
+    }
+    
+    private IEnumerable<IEnumerable<AssetResponseDto>> CreateChronologicalSets(IEnumerable<AssetResponseDto> allAssets, int setSize)
+    {
+        // Sort all assets by date
+        var sortedAssets = allAssets
+            .Where(a => a.ExifInfo?.DateTimeOriginal.HasValue == true)
+            .OrderBy(a => a.ExifInfo.DateTimeOriginal!.Value)
+            .ToList();
+            
+        if (!sortedAssets.Any())
+        {
+            // Fallback: create sets from randomly ordered assets if no date info available
+            var randomAssets = allAssets.OrderBy(_ => _random.Next()).ToList();
+            return CreateSetsFromList(randomAssets, setSize);
+        }
+        
+        // Create consecutive chronological sets
+        return CreateSetsFromList(sortedAssets, setSize);
+    }
+    
+    private IEnumerable<IEnumerable<AssetResponseDto>> CreateSetsFromList(List<AssetResponseDto> assets, int setSize)
+    {
+        var sets = new List<List<AssetResponseDto>>();
+        
+        for (int i = 0; i < assets.Count; i += setSize)
+        {
+            var set = assets.Skip(i).Take(setSize).ToList();
+            if (set.Any())
+            {
+                sets.Add(set);
+            }
+        }
+        
+        return sets;
+    }
+}

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -52,6 +52,8 @@ public class ServerSettingsV1 : IConfigSettable
     public bool ImagePan { get; set; } = false;
     public bool ImageFill { get; set; } = false;
     public string Layout { get; set; } = "splitview";
+    public bool ShowChronologicalImages { get; set; } = false;
+    public int ChronologicalImagesCount { get; set; } = 3;
 }
 
 /// <summary>
@@ -115,5 +117,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ImageFill => _delegate.ImageFill;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
+        public bool ShowChronologicalImages => _delegate.ShowChronologicalImages;
+        public int ChronologicalImagesCount => _delegate.ChronologicalImagesCount;
     }
 }

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -24,6 +24,8 @@ public class ClientSettingsDto
     public string Style { get; set; }
     public string? BaseFontSize { get; set; }
     public bool ShowWeatherDescription { get; set; }
+    public bool ShowChronologicalImages { get; set; }
+    public int ChronologicalImagesCount { get; set; }
     public string? WeatherIconUrl { get; set; }
     public bool ImageZoom { get; set; }
     public bool ImagePan { get; set; }
@@ -59,6 +61,8 @@ public class ClientSettingsDto
         dto.ImagePan = generalSettings.ImagePan;
         dto.ImageFill = generalSettings.ImageFill;
         dto.Layout = generalSettings.Layout;
+        dto.ShowChronologicalImages = generalSettings.ShowChronologicalImages;
+        dto.ChronologicalImagesCount = generalSettings.ChronologicalImagesCount;
         dto.Language = generalSettings.Language;
         return dto;
     }

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -52,6 +52,8 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public bool ImagePan { get; set; } = false;
     public bool ImageFill { get; set; } = false;
     public string Layout { get; set; } = "splitview";
+    public bool ShowChronologicalImages { get; set; } = true; //@todo default false?
+    public int ChronologicalImagesCount { get; set; } = 3;
     public int RenewImagesDuration { get; set; } = 30;
     public List<string> Webcalendars { get; set; } = new();
     public int RefreshAlbumPeopleInterval { get; set; } = 12;

--- a/docker/Settings.example.json
+++ b/docker/Settings.example.json
@@ -34,7 +34,9 @@
     "ImageZoom": true,
     "ImagePan": false,
     "ImageFill": false,
-    "Layout": "splitview"
+    "Layout": "splitview",
+    "ShowChronologicalImages": false,
+    "ChronologicalImagesCount": 3
   },
   "Accounts": [
     {

--- a/docker/Settings.example.yml
+++ b/docker/Settings.example.yml
@@ -33,6 +33,8 @@ General:
   ImagePan: false
   ImageFill: false
   Layout: splitview
+  ShowChronologicalImages: false
+  ChronologicalImagesCount: 3
 Accounts:
   - ImmichServerUrl: REQUIRED
     ApiKey: REQUIRED


### PR DESCRIPTION
## 🎯 Overview

This Pull Request introduces a new **experimental** feature that displays images in chronological sets. Images are grouped by their capture date and displayed in consecutive sets of `ChronologicalImagesCount` images, while the order of sets themselves is randomized for variety.

## ✨ Features Added

- **📅 Chronological Image Sets**: Images are sorted by their EXIF `DateTimeOriginal` and grouped into consecutive chronological sets
- **🎲 Randomized Set Order**: While individual sets maintain chronological order, the sets themselves are shuffled randomly
- **⚙️ Configurable Set Size**: Configure how many images appear in each chronological group via `ChronologicalImagesCount`
- **🔧 Toggle Feature**: Enable/disable the feature with `ShowChronologicalImages` setting
- **🔄 Graceful Fallback**: Falls back to standard random selection when chronological data is unavailable

## 🛠️ Technical Implementation

### Core Components

- **`ChronologicalAssetsPoolWrapper`**: New wrapper class that implements `IAssetPool` interface
  - Sorts assets by EXIF date information
  - Creates consecutive chronological sets of configurable size
  - Randomizes set order while preserving internal chronological order
  - Handles fallback scenarios when date metadata is missing

### Configuration Options

| Setting | Type | Default | Description |
|---------|------|---------|-------------|
| `ShowChronologicalImages` | `bool` | `false` | Enable/disable chronological image grouping |
| `ChronologicalImagesCount` | `int` | `3` | Number of images per chronological set |

### Algorithm Flow

1. **Asset Retrieval**: Fetches a larger pool of assets for better chronological selection
2. **Date Sorting**: Filters and sorts assets by `ExifInfo.DateTimeOriginal`
3. **Set Creation**: Groups consecutive chronological images into sets of specified size
4. **Set Randomization**: Shuffles the order of sets while maintaining internal chronological order
5. **Result Selection**: Flattens sets and returns the requested number of images

## 📁 Files Modified

### Core Logic
- `ImmichFrame.Core/Logic/Pool/ChronologicalAssetsPoolWrapper.cs` *(new)*
- `ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs`
- `ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs`

### Configuration & Models
- `ImmichFrame.Core/Interfaces/IServerSettings.cs`
- `ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs`
- `ImmichFrame.WebApi/Models/ClientSettingsDto.cs`
- `ImmichFrame.WebApi/Models/ServerSettings.cs`

### Configuration Examples
- `docker/Settings.example.json`
- `docker/Settings.example.yml`

## 🎮 Usage Example

```json
{
  "General": {
    "ShowChronologicalImages": true,
    "ChronologicalImagesCount": 3
  }
}
```

This configuration will:
- Display images in sets of 3 consecutive chronological images
- Randomize the order of these sets
- Maintain chronological order within each set (e.g., morning → afternoon → evening)

## 🧪 Experimental Status

This feature is marked as **experimental** and may undergo changes based on user feedback. The implementation:

- ✅ Handles missing EXIF date information gracefully
- ✅ Provides configurable fallback to standard behavior
- ✅ Maintains performance with efficient asset pooling
- ⚠️ May benefit from additional configuration options in future iterations

## 🔧 Configuration Details

The feature can be enabled in your settings file:

**JSON Configuration:**
```json
{
  "General": {
    "ShowChronologicalImages": true,
    "ChronologicalImagesCount": 3
  }
}
```

**YAML Configuration:**
```yaml
General:
  ShowChronologicalImages: true
  ChronologicalImagesCount: 3
```

**Environment Variables:**
```bash
ShowChronologicalImages=true
ChronologicalImagesCount=3
```

## 🎯 Use Cases

- **📸 Photo Stories**: Display images from events in chronological order
- **🎭 Variety with Order**: Maintain temporal context while keeping displays interesting
- **📅 Time-based Narratives**: Show progression of activities, trips, or celebrations
- **🔀 Balanced Randomization**: Prevent repetitive patterns while preserving meaningful sequences

---

*This feature enhances the ImmichFrame experience by adding temporal context to image displays while maintaining the dynamic, varied presentation users expect.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Optional chronological photo display that groups images by date; preserves order within each group. Group size is configurable.
- Settings
  - Added ShowChronologicalImages and ChronologicalImagesCount to enable and configure chronological grouping across server and client settings.
- Documentation
  - Updated example JSON/YAML configuration files to include the new settings and guidance on usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->