### PR TITLE
Add setting to adjust temperature number display style

### DIFF
--- a/ImmichFrame.Core/Interfaces/IClientSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IClientSettings.cs
@@ -23,6 +23,7 @@ namespace ImmichFrame.Core.Interfaces
         public string Style { get; }
         public string? BaseFontSize { get; }
         public bool ShowWeatherDescription { get; }
+        public int TemperatureDecimalDigits { get; }
         public string? WeatherIconUrl { get; }
         public bool ImageZoom { get; }
         public bool ImagePan { get; }

--- a/ImmichFrame.WebApi.Tests/Models/TemperatureDecimalDigitsValidationTests.cs
+++ b/ImmichFrame.WebApi.Tests/Models/TemperatureDecimalDigitsValidationTests.cs
@@ -1,0 +1,50 @@
+using NUnit.Framework;
+using ImmichFrame.WebApi.Helpers;
+using ImmichFrame.WebApi.Models;
+
+namespace ImmichFrame.WebApi.Tests.Models;
+
+[TestFixture]
+public class TemperatureDecimalDigitsValidationTests
+{
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void GeneralSettings_AcceptsSupportedPrecision(int digits)
+    {
+        var settings = new GeneralSettings { TemperatureDecimalDigits = digits };
+
+        Assert.DoesNotThrow(() => settings.Validate());
+    }
+
+    [TestCase(-1)]
+    [TestCase(3)]
+    [TestCase(101)]
+    public void GeneralSettings_RejectsUnsupportedPrecision(int digits)
+    {
+        var settings = new GeneralSettings { TemperatureDecimalDigits = digits };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => settings.Validate());
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    public void V1Config_AcceptsSupportedPrecision(int digits)
+    {
+        var v1 = new ServerSettingsV1 { TemperatureDecimalDigits = digits };
+
+        Assert.DoesNotThrow(() => new ServerSettingsV1Adapter(v1).GeneralSettings.Validate());
+    }
+
+    [TestCase(-1)]
+    [TestCase(101)]
+    public void V1Config_RejectsUnsupportedPrecision(int digits)
+    {
+        var v1 = new ServerSettingsV1 { TemperatureDecimalDigits = digits };
+
+        Assert.That(() => new ServerSettingsV1Adapter(v1).GeneralSettings.Validate(),
+            Throws.TypeOf<ArgumentOutOfRangeException>(),
+            "a legacy config must not pass through a value that would throw RangeError in toFixed()");
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Resources/TestV1.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV1.json
@@ -51,6 +51,7 @@
     "BaseFontSize": "BaseFontSize_TEST",
     "WeatherApiKey": "WeatherApiKey_TEST",
     "ShowWeatherDescription": true,
+    "TemperatureDecimalDigits": 7,
     "WeatherIconUrl": "WeatherIconUrl_TEST",
     "UnitSystem": "UnitSystem_TEST",
     "WeatherLatLong": "WeatherLatLong_TEST",

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.json
@@ -30,6 +30,7 @@
     "Style": "Style_TEST",
     "BaseFontSize": "BaseFontSize_TEST",
     "ShowWeatherDescription": true,
+    "TemperatureDecimalDigits": 7,
     "WeatherIconUrl": "WeatherIconUrl_TEST",
     "ImageZoom": true,
     "ImagePan": true,

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
@@ -29,6 +29,7 @@ General:
   Style: Style_TEST
   BaseFontSize: BaseFontSize_TEST
   ShowWeatherDescription: true
+  TemperatureDecimalDigits: 7
   WeatherIconUrl: WeatherIconUrl_TEST
   ImageZoom: true
   ImagePan: true

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -50,6 +50,7 @@ public class ServerSettingsV1 : IConfigSettable
     public string Style { get; set; } = "none";
     public string? BaseFontSize { get; set; }
     public bool ShowWeatherDescription { get; set; } = true;
+    public int TemperatureDecimalDigits { get; set; } = 1;
     public string? WeatherIconUrl { get; set; } = "https://openweathermap.org/img/wn/{IconId}.png";
     public bool ImageZoom { get; set; } = true;
     public bool ImagePan { get; set; } = false;
@@ -128,6 +129,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public string Style => _delegate.Style;
         public string? BaseFontSize => _delegate.BaseFontSize;
         public bool ShowWeatherDescription => _delegate.ShowWeatherDescription;
+        public int TemperatureDecimalDigits => _delegate.TemperatureDecimalDigits;
         public string? WeatherIconUrl => _delegate.WeatherIconUrl;
         public bool ImageZoom => _delegate.ImageZoom;
         public bool ImagePan => _delegate.ImagePan;
@@ -136,6 +138,14 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
 
-        public void Validate() { }
+        public void Validate()
+        {
+            if (TemperatureDecimalDigits < 0 || TemperatureDecimalDigits > 2)
+            {
+                throw new ArgumentOutOfRangeException(nameof(TemperatureDecimalDigits),
+                    TemperatureDecimalDigits,
+                    "TemperatureDecimalDigits must be between 0 and 2.");
+            }
+        }
     }
 }

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -25,6 +25,7 @@ public class ClientSettingsDto(IClientSettings settings) : IClientSettings
     public string Style => settings.Style;
     public string? BaseFontSize => settings.BaseFontSize;
     public bool ShowWeatherDescription => settings.ShowWeatherDescription;
+    public int TemperatureDecimalDigits => settings.TemperatureDecimalDigits;
     public string? WeatherIconUrl => settings.WeatherIconUrl;
     public bool ImageZoom => settings.ImageZoom;
     public bool ImagePan => settings.ImagePan;

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -58,6 +58,7 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string Style { get; set; } = "none";
     public string? BaseFontSize { get; set; }
     public bool ShowWeatherDescription { get; set; } = true;
+    public int TemperatureDecimalDigits { get; set; } = 1;
     public string? WeatherIconUrl { get; set; } = "https://openweathermap.org/img/wn/{IconId}.png";
     public bool ImageZoom { get; set; } = true;
     public bool ImagePan { get; set; } = false;
@@ -73,7 +74,15 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string? Webhook { get; set; }
     public string? AuthenticationSecret { get; set; }
 
-    public void Validate() { }
+    public void Validate()
+    {
+        if (TemperatureDecimalDigits < 0 || TemperatureDecimalDigits > 2)
+        {
+            throw new ArgumentOutOfRangeException(nameof(TemperatureDecimalDigits),
+                TemperatureDecimalDigits,
+                "TemperatureDecimalDigits must be between 0 and 2.");
+        }
+    }
 }
 
 public class ServerAccountSettings : IAccountSettings, IConfigSettable

--- a/docker/Settings.example.json
+++ b/docker/Settings.example.json
@@ -30,6 +30,7 @@
     "Style": "none",
     "BaseFontSize": "17px",
     "ShowWeatherDescription": true,
+    "TemperatureDecimalDigits": 1,
     "WeatherIconUrl": "https://openweathermap.org/img/wn/{IconId}.png",
     "ImageZoom": true,
     "ImagePan": false,

--- a/docker/Settings.example.yml
+++ b/docker/Settings.example.yml
@@ -28,6 +28,7 @@ General:
   Style: none
   BaseFontSize: 17px
   ShowWeatherDescription: true
+  TemperatureDecimalDigits: 1
   WeatherIconUrl: 'https://openweathermap.org/img/wn/{IconId}.png'
   ImageZoom: true
   ImagePan: false

--- a/docker/example.env
+++ b/docker/example.env
@@ -43,6 +43,7 @@ ApiKey=KEY
 # BaseFontSize=17px
 # WeatherApiKey=
 # ShowWeatherDescription=true
+# TemperatureDecimalDigits=1
 # WeatherIconUrl=https://openweathermap.org/img/wn/{IconId}.png
 # UnitSystem=imperial
 # WeatherLatLong=

--- a/immichFrame.Web/src/lib/components/elements/clock.svelte
+++ b/immichFrame.Web/src/lib/components/elements/clock.svelte
@@ -90,7 +90,7 @@
             {/if}
             
             <div class="weather-location">{weather.location},</div>
-            <div class="weather-temperature">{weather.temperature?.toFixed(1)}°</div>
+            <div class="weather-temperature">{weather.temperature?.toFixed($configStore.temperatureDecimalDigits ?? 1)}°</div>
         </div>
         
         {#if $configStore.showWeatherDescription}

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -221,6 +221,7 @@ export type ClientSettingsDto = {
     style?: string | null;
     baseFontSize?: string | null;
     showWeatherDescription?: boolean;
+    temperatureDecimalDigits?: number;
     weatherIconUrl?: string | null;
     imageZoom?: boolean;
     imagePan?: boolean;

--- a/openApi/swagger.json
+++ b/openApi/swagger.json
@@ -1069,6 +1069,10 @@
           "showWeatherDescription": {
             "type": "boolean"
           },
+          "temperatureDecimalDigits": {
+            "type": "integer",
+            "format": "int32"
+          },
           "weatherIconUrl": {
             "type": "string",
             "nullable": true


### PR DESCRIPTION
Adds boolean setting "UseWholeNumberTemperatures" to display temperature as integer (whole numbers) in order to simplify display. 

When set to false or not set, the default is to display Temperature as decimal. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added settings to show videos, display account tags, show tag descriptions, and play audio.
  - Added configurable weather temperature precision, supporting 0–2 decimal places and defaulting to 1.
  - Exposed the new settings through the client settings API.

- **Bug Fixes**
  - Weather temperatures now respect the configured decimal precision instead of always showing one decimal place.

- **Documentation**
  - Updated sample JSON, YAML, and environment configurations with the new options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->