### PR TITLE
feat: add AssetBatchSize and client persist options

### DIFF
--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -62,6 +62,9 @@
         public bool ImageFill { get; }
         public string Layout { get; }
         public string Language { get; }
+        public int AssetBatchSize { get; }
+        public bool ClientPersistAssetQueue { get; }
+        public bool ClientPersistAssetHistory { get; }
 
         public void Validate();
     }

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -64,7 +64,7 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
     public Task<IEnumerable<AssetResponseDto>> GetAssets()
     {
-        return _pool.GetAssets(25);
+        return _pool.GetAssets(_generalSettings.AssetBatchSize);
     }
 
     public Task<AssetResponseDto> GetAssetInfoById(Guid assetId) => _immichApi.GetAssetInfoAsync(assetId, null);

--- a/ImmichFrame.WebApi/Controllers/ConfigController.cs
+++ b/ImmichFrame.WebApi/Controllers/ConfigController.cs
@@ -1,4 +1,5 @@
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -10,11 +11,13 @@ namespace ImmichFrame.WebApi.Controllers
     {
         private readonly ILogger<AssetController> _logger;
         private readonly IGeneralSettings _settings;
+        private readonly ServerSession _serverSession;
 
-        public ConfigController(ILogger<AssetController> logger, IGeneralSettings settings)
+        public ConfigController(ILogger<AssetController> logger, IGeneralSettings settings, ServerSession serverSession)
         {
             _logger = logger;
             _settings = settings;
+            _serverSession = serverSession;
         }
 
         [HttpGet(Name = "GetConfig")]
@@ -22,7 +25,7 @@ namespace ImmichFrame.WebApi.Controllers
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Config requested by '{sanitizedClientIdentifier}'", sanitizedClientIdentifier);
-            return ClientSettingsDto.FromGeneralSettings(_settings);
+            return ClientSettingsDto.FromGeneralSettings(_settings, _serverSession.SessionId);
         }
 
         [HttpGet("Version", Name = "GetVersion")]

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -126,6 +126,9 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ImageFill => _delegate.ImageFill;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
+        public int AssetBatchSize => 25;  // Default value for V1 config
+        public bool ClientPersistAssetQueue => false;  // Default value for V1 config
+        public bool ClientPersistAssetHistory => false;  // Default value for V1 config
 
         public void Validate() { }
     }

--- a/ImmichFrame.WebApi/Helpers/ServerSession.cs
+++ b/ImmichFrame.WebApi/Helpers/ServerSession.cs
@@ -1,0 +1,10 @@
+namespace ImmichFrame.WebApi.Helpers;
+
+/// <summary>
+/// Holds a unique session ID generated at server startup.
+/// Used by clients to detect server restarts and clear stale persisted data.
+/// </summary>
+public class ServerSession
+{
+    public string SessionId { get; } = Guid.NewGuid().ToString();
+}

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -30,6 +30,9 @@ public class ClientSettingsDto
     public bool ImageFill { get; set; }
     public string Layout { get; set; }
     public string Language { get; set; }
+    public int AssetBatchSize { get; set; }
+    public bool ClientPersistAssetQueue { get; set; }
+    public bool ClientPersistAssetHistory { get; set; }
 
     public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings)
     {
@@ -60,6 +63,9 @@ public class ClientSettingsDto
         dto.ImageFill = generalSettings.ImageFill;
         dto.Layout = generalSettings.Layout;
         dto.Language = generalSettings.Language;
+        dto.AssetBatchSize = generalSettings.AssetBatchSize;
+        dto.ClientPersistAssetQueue = generalSettings.ClientPersistAssetQueue;
+        dto.ClientPersistAssetHistory = generalSettings.ClientPersistAssetHistory;
         return dto;
     }
 }

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -33,8 +33,9 @@ public class ClientSettingsDto
     public int AssetBatchSize { get; set; }
     public bool ClientPersistAssetQueue { get; set; }
     public bool ClientPersistAssetHistory { get; set; }
+    public string ServerSessionId { get; set; } = string.Empty;
 
-    public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings)
+    public static ClientSettingsDto FromGeneralSettings(IGeneralSettings generalSettings, string serverSessionId = "")
     {
         ClientSettingsDto dto = new ClientSettingsDto();
         dto.Interval = generalSettings.Interval;
@@ -66,6 +67,7 @@ public class ClientSettingsDto
         dto.AssetBatchSize = generalSettings.AssetBatchSize;
         dto.ClientPersistAssetQueue = generalSettings.ClientPersistAssetQueue;
         dto.ClientPersistAssetHistory = generalSettings.ClientPersistAssetHistory;
+        dto.ServerSessionId = serverSessionId;
         return dto;
     }
 }

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -74,7 +74,13 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public bool ClientPersistAssetQueue { get; set; } = false;
     public bool ClientPersistAssetHistory { get; set; } = false;
 
-    public void Validate() { }
+    public void Validate()
+    {
+        if (AssetBatchSize < 1)
+        {
+            AssetBatchSize = 1;
+        }
+    }
 }
 
 public class ServerAccountSettings : IAccountSettings, IConfigSettable

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -70,6 +70,9 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string? WeatherLatLong { get; set; } = "40.7128,74.0060";
     public string? Webhook { get; set; }
     public string? AuthenticationSecret { get; set; }
+    public int AssetBatchSize { get; set; } = 25;
+    public bool ClientPersistAssetQueue { get; set; } = false;
+    public bool ClientPersistAssetHistory { get; set; } = false;
 
     public void Validate() { }
 }

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -57,6 +57,7 @@ builder.Services.AddSingleton<IServerSettings>(srv => srv.GetRequiredService<Con
 builder.Services.AddSingleton<IGeneralSettings>(srv => srv.GetRequiredService<IServerSettings>().GeneralSettings);
 
 // Register services
+builder.Services.AddSingleton<ImmichFrame.WebApi.Helpers.ServerSession>();
 builder.Services.AddSingleton<IWeatherService, OpenWeatherMapService>();
 builder.Services.AddSingleton<ICalendarService, IcalCalendarService>();
 builder.Services.AddSingleton<IAssetAccountTracker, BloomFilterAssetAccountTracker>();

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -98,6 +98,16 @@ General:
   ImageFill: false  # boolean
   # Allow two portrait images to be displayed next to each other
   Layout: 'splitview'  # single | splitview
+  # Number of assets to fetch per batch request
+  AssetBatchSize: 25  # int
+  # Persist current and upcoming assets in client localStorage across restarts.
+  # WARNING: Assets may become stale if removed from albums while stored locally.
+  # Set to false and restart clients to clear stored data.
+  ClientPersistAssetQueue: false  # boolean
+  # Persist asset history (back button) in client localStorage across restarts
+  # WARNING: Assets may become stale if removed from albums while stored locally.
+  # Set to false and restart clients to clear stored data.
+  ClientPersistAssetHistory: false  # boolean
 
 # multiple accounts permitted
 Accounts:

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -101,12 +101,10 @@ General:
   # Number of assets to fetch per batch request
   AssetBatchSize: 25  # int
   # Persist current and upcoming assets in client localStorage across restarts.
-  # WARNING: Assets may become stale if removed from albums while stored locally.
-  # Set to false and restart clients to clear stored data.
+  # Note: A server restart will clear the queue on all clients.
   ClientPersistAssetQueue: false  # boolean
-  # Persist asset history (back button) in client localStorage across restarts
-  # WARNING: Assets may become stale if removed from albums while stored locally.
-  # Set to false and restart clients to clear stored data.
+  # Persist asset history (back button) in client localStorage across restarts.
+  # Note: A server restart will clear the history on all clients.
   ClientPersistAssetHistory: false  # boolean
 
 # multiple accounts permitted

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -345,16 +345,21 @@
 		// This prevents stale assets that the server's BloomFilter doesn't know about
 		const currentServerSessionId = $configStore.serverSessionId;
 		const storedServerSessionId = $serverSessionIdStore;
-		if (currentServerSessionId == null || storedServerSessionId !== currentServerSessionId) {
+		const sessionChanged = currentServerSessionId == null || storedServerSessionId !== currentServerSessionId;
+		if (sessionChanged) {
 			clearPersistedStore('assetBacklog');
 			clearPersistedStore('assetHistory');
 			clearPersistedStore('displayingAssets');
+			// Also reset the in-memory stores
+			assetBacklogStore.set([]);
+			assetHistoryStore.set([]);
+			displayingAssetsStore.set([]);
 			serverSessionIdStore.set(currentServerSessionId);
 		}
 
 		// load persisted asset queue and displaying assets
 		let restoredDisplaying = false;
-		if ($configStore.clientPersistAssetQueue) {
+		if ($configStore.clientPersistAssetQueue && !sessionChanged) {
 			const storedBacklog = $assetBacklogStore as api.AssetResponseDto[];
 			if (storedBacklog && storedBacklog.length > 0) {
 				assetBacklog = storedBacklog;
@@ -367,7 +372,7 @@
 		}
 
 		// load persisted asset history
-		if ($configStore.clientPersistAssetHistory) {
+		if ($configStore.clientPersistAssetHistory && !sessionChanged) {
 			const stored = $assetHistoryStore as api.AssetResponseDto[];
 			if (stored && stored.length > 0) {
 				assetHistory = stored;

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -2,7 +2,7 @@
 	import * as api from '$lib/index';
 	import ProgressBar from '$lib/components/elements/progress-bar.svelte';
 	import { slideshowStore } from '$lib/stores/slideshow.store';
-	import { clientIdentifierStore, authSecretStore } from '$lib/stores/persist.store';
+	import { clientIdentifierStore, authSecretStore, assetBacklogStore, assetHistoryStore, displayingAssetsStore, clearPersistedStore } from '$lib/stores/persist.store';
 	import { onDestroy, onMount, setContext } from 'svelte';
 	import OverlayControls from '../elements/overlay-controls.svelte';
 	import ImageComponent from '../elements/image-component.svelte';
@@ -29,6 +29,32 @@
 
 	let assetHistory: api.AssetResponseDto[] = [];
 	let assetBacklog: api.AssetResponseDto[] = [];
+
+	// persist helpers - save to localStorage if enabled
+	function persistBacklog() {
+		if ($configStore.clientPersistAssetQueue) {
+			assetBacklogStore.set(assetBacklog);
+		}
+	}
+
+	function persistHistory() {
+		if ($configStore.clientPersistAssetHistory) {
+			assetHistoryStore.set(assetHistory);
+		}
+	}
+
+	function persistDisplaying() {
+		if ($configStore.clientPersistAssetQueue) {
+			displayingAssetsStore.set(displayingAssets);
+		}
+	}
+
+	async function showAssets(assets: api.AssetResponseDto[]) {
+		displayingAssets = assets;
+		persistDisplaying();
+		updateImagePromises();
+		imagesState = await loadImages(assets);
+	}
 
 	let displayingAssets: api.AssetResponseDto[] = $state() as api.AssetResponseDto[];
 
@@ -118,7 +144,7 @@
 
 	async function loadAssets() {
 		try {
-			let assetRequest = await api.getAsset();
+			let assetRequest = await api.getAsset({ clientIdentifier: $clientIdentifierStore });
 
 			if (assetRequest.status != 200) {
 				if (assetRequest.status == 401) {
@@ -130,6 +156,7 @@
 
 			error = false;
 			assetBacklog = assetRequest.data;
+			persistBacklog();
 		} catch {
 			error = true;
 		}
@@ -166,6 +193,7 @@
 			next = assetBacklog.splice(0, 1);
 		}
 		assetBacklog = [...assetBacklog];
+		persistBacklog();
 
 		if (displayingAssets) {
 			// Push to History
@@ -176,10 +204,9 @@
 		if (assetHistory.length > 250) {
 			assetHistory = assetHistory.splice(assetHistory.length - 250, 250);
 		}
+		persistHistory();
 
-		displayingAssets = next;
-		updateImagePromises();
-		imagesState = await loadImages(next);
+		await showAssets(next);
 	}
 
 	async function getPreviousAssets() {
@@ -200,14 +227,16 @@
 		}
 
 		assetHistory = [...assetHistory];
+		persistHistory();
 
 		// Unshift to Backlog
 		if (displayingAssets) {
 			assetBacklog.unshift(...displayingAssets);
 		}
-		displayingAssets = next;
-		updateImagePromises();
-		imagesState = await loadImages(next);
+		assetBacklog = [...assetBacklog];
+		persistBacklog();
+
+		await showAssets(next);
 	}
 
 	function isHorizontal(asset: api.AssetResponseDto) {
@@ -312,6 +341,33 @@
 			document.documentElement.style.fontSize = $configStore.baseFontSize;
 		}
 
+		// load or clear persisted asset queue and displaying assets
+		let restoredDisplaying = false;
+		if ($configStore.clientPersistAssetQueue) {
+			const storedBacklog = $assetBacklogStore as api.AssetResponseDto[];
+			if (storedBacklog && storedBacklog.length > 0) {
+				assetBacklog = storedBacklog;
+			}
+			const storedDisplaying = $displayingAssetsStore as api.AssetResponseDto[];
+			if (storedDisplaying && storedDisplaying.length > 0) {
+				displayingAssets = storedDisplaying;
+				restoredDisplaying = true;
+			}
+		} else {
+			clearPersistedStore('assetBacklog');
+			clearPersistedStore('displayingAssets');
+		}
+
+		// load or clear persisted asset history
+		if ($configStore.clientPersistAssetHistory) {
+			const stored = $assetHistoryStore as api.AssetResponseDto[];
+			if (stored && stored.length > 0) {
+				assetHistory = stored;
+			}
+		} else {
+			clearPersistedStore('assetHistory');
+		}
+
 		unsubscribeRestart = restartProgress.subscribe((value) => {
 			if (value) {
 				progressBar.restart(value);
@@ -324,7 +380,11 @@
 			}
 		});
 
-		getNextAssets();
+		if (restoredDisplaying) {
+			showAssets(displayingAssets);
+		} else {
+			getNextAssets();
+		}
 
 		return () => {
 			window.removeEventListener('mousemove', showCursor);

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -212,6 +212,9 @@ export type ClientSettingsDto = {
     imageFill?: boolean;
     layout?: string | null;
     language?: string | null;
+    assetBatchSize?: number;
+    clientPersistAssetQueue?: boolean;
+    clientPersistAssetHistory?: boolean;
 };
 export type IWeather = {
     location?: string | null;

--- a/immichFrame.Web/src/lib/stores/persist.store.ts
+++ b/immichFrame.Web/src/lib/stores/persist.store.ts
@@ -41,6 +41,7 @@ function generateGUID() {
 
 export const clientIdentifierStore = persistStore('clientIdentifier', generateGUID());
 export const authSecretStore = persistStore('authSecret', null);
+export const serverSessionIdStore = persistStore('serverSessionId', null);
 export const assetBacklogStore = persistArrayStore<unknown>('assetBacklog', []);
 export const assetHistoryStore = persistArrayStore<unknown>('assetHistory', []);
 export const displayingAssetsStore = persistArrayStore<unknown>('displayingAssets', []);

--- a/immichFrame.Web/src/lib/stores/persist.store.ts
+++ b/immichFrame.Web/src/lib/stores/persist.store.ts
@@ -14,6 +14,23 @@ function persistStore(key: string, defaultValue: string | null) {
     return store;
 }
 
+function persistArrayStore<T>(key: string, defaultValue: T[]) {
+    const storedValue = localStorage?.getItem(key);
+    const initialValue: T[] = storedValue ? JSON.parse(storedValue) : defaultValue;
+
+    const store = writable(initialValue);
+
+    store.subscribe((value) => {
+        localStorage?.setItem(key, JSON.stringify(value));
+    });
+
+    return store;
+}
+
+export function clearPersistedStore(key: string) {
+    localStorage?.removeItem(key);
+}
+
 function generateGUID() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
         const r = (Math.random() * 16) | 0,
@@ -24,3 +41,6 @@ function generateGUID() {
 
 export const clientIdentifierStore = persistStore('clientIdentifier', generateGUID());
 export const authSecretStore = persistStore('authSecret', null);
+export const assetBacklogStore = persistArrayStore<unknown>('assetBacklog', []);
+export const assetHistoryStore = persistArrayStore<unknown>('assetHistory', []);
+export const displayingAssetsStore = persistArrayStore<unknown>('displayingAssets', []);


### PR DESCRIPTION
## Summary
### Add `AssetBatchSize` config option to control how many assets are fetched per batch (default: 25)
Rationale: Currently this is hardcoded to 25 but that means after 25 images you get a new batch of random assets where there could be collisions, making this configurable allows the user to determine how long they want to go before possible seeing duplicate assets.

### Add `ClientPersistAssetQueue` to persist current and upcoming assets in localStorage across browser restarts
### Add `ClientPersistAssetHistory` to persist asset history in localStorage for back button functionality after refresh
Rationale: Currently if the client restarts (e.g. due to a power cycle on the TV or the app gets unintentionally closed, all viewed items and the current queue gets reset. This means
1. You can go back to view history anymore
2. You get a fresh batch of assets that might again, be duplicates of those you already viewed recently
This makes it configurable to choose for all clients to persist the history and queue so you don't loose your place just because the app got closed.

#### Open questions/considerations
- This should maybe be a client side config - Ideally I actually think this should be a config on the client side especially for the android app, but I don't have much experience with android dev so this was the next best thing
- Should these be the same config - I can see arguments for both my current solution and for this being one config option instead of 2, but I figured it's never a bad idea to have more configurability. I'm happy to change this if maintainers think otherwise.
- Assets stored might become stale (i.e. no longer supposed to be server by the server) - This is valid and so i added a warning in the config to flag this, setting the config to false will also clear the state for any user who runs into this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable asset batch size (default 25) for asset loading.
  * Optional client-side persistence for asset queue and viewing history; restored on load and resumes viewing when available.
  * Server session ID exposed so clients can detect server restarts; asset requests include a client identifier.

* **Documentation**
  * Configuration guide updated with the new settings and notes about persistence behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->