### PR TITLE
feat: improve splitview horizontal image pairing

### DIFF
--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -199,7 +199,7 @@
 		imagesState = await loadImages(next);
 	}
 
-	function isHorizontal(asset: api.AssetResponseDto) {
+	function isPortrait(asset: api.AssetResponseDto) {
 		const isFlipped = (orientation: number) => [5, 6, 7, 8].includes(orientation);
 		let imageHeight = asset.exifInfo?.exifImageHeight ?? 0;
 		let imageWidth = asset.exifInfo?.exifImageWidth ?? 0;
@@ -215,7 +215,8 @@
 	}
 
 	// Selects which assets to display based on layout and orientation
-	// For splitview, tries to pair horizontal images together
+	// For splitview, tries to pair portrait images together, to be shown side by side
+	// Landscape images are shown alone
 	function selectAssetsForDisplay(layout: string | undefined, candidates: api.AssetResponseDto[]): number[] {
 		if (candidates.length < 1) {
 			return [];
@@ -224,27 +225,30 @@
 			return [0];
 		}
 
-		const h0 = isHorizontal(candidates[0]);
-		const h1 = candidates.length > 1 ? isHorizontal(candidates[1]) : false;
-		const h2 = candidates.length > 2 ? isHorizontal(candidates[2]) : false;
+		const isImage0Portrait = isPortrait(candidates[0]);
+		const isImage1Portrait = candidates.length > 1 ? isPortrait(candidates[1]) : false;
+		const isImage2Portrait = candidates.length > 2 ? isPortrait(candidates[2]) : false;
 
-		if (!h0) {
-			// first image is vertical, show it alone
+		if (!isImage0Portrait) {
+			// first image is landscape, show it alone
 			return [0];
 		}
 
-		// pair with second if it's also horizontal
-		if (candidates.length > 1 && h1) {
+		
+		if (candidates.length > 1 && isImage1Portrait) {
+			// pair with second if it's also portrait
 			return [0, 1];
 		}
 
-		// pair with third if it's horizontal (skip non-horizontal second)
-		if (candidates.length > 2 && h2) {
+		
+		if (candidates.length > 2 && isImage2Portrait) {
+			// pair with third if it's portrait (skip landscape second)
 			return [0, 2];
 		}
+
 		
-		// no horizontal pair found, show second instead (skip lone horizontal)
-		if (candidates.length > 1) {
+		if (candidates[1] != null) {
+			// no portrait pair found, show second (landscape) instead
 			return [1];
 		}
 		return [0];

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -184,8 +184,8 @@
 		const candidates = assetHistory.slice(historyLength - Math.min(3, historyLength)).reverse();
 		const selectedIndices = selectAssetsForDisplay($configStore.layout, candidates);
 
-		// convert indices back to history positions
-		const historyIndices = selectedIndices.map((i) => historyLength - 1 - i);
+		// convert indices back to history positions and reverse to restore original display order
+		const historyIndices = selectedIndices.map((i) => historyLength - 1 - i).reverse();
 		const next = historyIndices.map((i) => assetHistory[i]);
 		assetHistory = removeAtIndices(assetHistory, historyIndices);
 

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -181,8 +181,7 @@
 
 		// get up to 3 candidates from the end of history, reversed for selection logic
 		const historyLength = assetHistory.length;
-		const candidateCount = Math.min(3, historyLength);
-		const candidates = assetHistory.slice(historyLength - candidateCount).reverse();
+		const candidates = assetHistory.slice(historyLength - Math.min(3, historyLength)).reverse();
 		const selectedIndices = selectAssetsForDisplay($configStore.layout, candidates);
 
 		// convert indices back to history positions
@@ -234,6 +233,7 @@
 			return [0];
 		}
 
+		// otherwise, first image is portrait
 		
 		if (candidates.length > 1 && isImage1Portrait) {
 			// pair with second if it's also portrait
@@ -251,6 +251,8 @@
 			// no portrait pair found, show second (landscape) instead
 			return [1];
 		}
+
+		// Unreachable state, but fallback to returning the first image.
 		return [0];
 	}
 

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -137,7 +137,7 @@
 
 	async function loadAssets() {
 		try {
-			let assetRequest = await api.getAssets();
+			let assetRequest = await api.getAssets({ clientIdentifier: $clientIdentifierStore });
 
 			if (assetRequest.status != 200) {
 				if (assetRequest.status == 401) {
@@ -230,8 +230,10 @@
 			return;
 		}
 
-		const useSplit = shouldUseSplitView(assetBacklog);
-		const next = assetBacklog.splice(0, useSplit ? 2 : 1);
+		const candidates = assetBacklog.slice(0, 3);
+		const selectedIndices = selectAssetsForDisplay($configStore.layout, candidates);
+		const next = selectedIndices.map((i) => assetBacklog[i]);
+		assetBacklog = removeAtIndices(assetBacklog, selectedIndices);
 
 		if (displayingAssets.length) {
 			assetHistory.push(...displayingAssets);
@@ -251,8 +253,16 @@
 			return;
 		}
 
-		const useSplit = shouldUseSplitView(assetHistory.slice(-2));
-		const next = assetHistory.splice(useSplit ? -2 : -1);
+		// Take up to 3 most-recent history entries, reversed so the selection logic
+		// treats the most recently shown asset as the "first" candidate.
+		const historyLength = assetHistory.length;
+		const candidates = assetHistory.slice(historyLength - Math.min(3, historyLength)).reverse();
+		const selectedIndices = selectAssetsForDisplay($configStore.layout, candidates);
+
+		// Convert candidate indices back to history positions and restore display order.
+		const historyIndices = selectedIndices.map((i) => historyLength - 1 - i).reverse();
+		const next = historyIndices.map((i) => assetHistory[i]);
+		assetHistory = removeAtIndices(assetHistory, historyIndices);
 
 		if (displayingAssets.length) {
 			assetBacklog.unshift(...displayingAssets);
@@ -277,15 +287,53 @@
 		return assetHeight > assetWidth;
 	}
 
-	function shouldUseSplitView(assets: api.AssetResponseDto[]): boolean {
-		return (
-			$configStore.layout?.trim().toLowerCase() === 'splitview' &&
-			assets.length > 1 &&
-			isImageAsset(assets[0]) &&
-			isImageAsset(assets[1]) &&
-			isPortrait(assets[0]) &&
-			isPortrait(assets[1])
-		);
+	function removeAtIndices<T>(arr: T[], indicesToRemove: number[]): T[] {
+		const skipSet = new Set(indicesToRemove);
+		return arr.filter((_, i) => !skipSet.has(i));
+	}
+
+	// Selects which assets to display based on layout and orientation.
+	// For splitview, tries to pair portrait images together, to be shown side by side.
+	// Landscape images (and videos, which isPortrait treats as non-portrait) are shown alone.
+	function selectAssetsForDisplay(
+		layout: string | null | undefined,
+		candidates: api.AssetResponseDto[]
+	): number[] {
+		if (candidates.length < 1) {
+			return [];
+		}
+		if (candidates.length === 1 || layout?.trim().toLowerCase() !== 'splitview') {
+			return [0];
+		}
+
+		const isImage0Portrait = isPortrait(candidates[0]);
+		const isImage1Portrait = candidates.length > 1 ? isPortrait(candidates[1]) : false;
+		const isImage2Portrait = candidates.length > 2 ? isPortrait(candidates[2]) : false;
+
+		if (!isImage0Portrait) {
+			// first image is landscape, show it alone
+			return [0];
+		}
+
+		// otherwise, first image is portrait
+
+		if (candidates.length > 1 && isImage1Portrait) {
+			// pair with second if it's also portrait
+			return [0, 1];
+		}
+
+		if (candidates.length > 2 && isImage2Portrait) {
+			// pair with third if it's portrait (skip landscape second)
+			return [0, 2];
+		}
+
+		if (candidates[1] != null) {
+			// no portrait pair found, show second (landscape) instead
+			return [1];
+		}
+
+		// Unreachable state, but fallback to returning the first image.
+		return [0];
 	}
 
 	function hasBirthday(assets: api.AssetResponseDto[]) {


### PR DESCRIPTION
**Problem:** The current `splitview` logic only paired portrait images if they were adjacent in the queue. If a landscape image was between two portrait ones, the first portrait would display alone. 

This kind of defeats the purpose of the `splitview` layout, if sometimes you still get portrait images standing alone. The order of assets in the queue is random so we can move stuff around to ensure portrait images are always paired in `splitview`

## Change Summary
Smarter portrait image pairing in `splitview `layout - looks ahead at 3 candidates instead of 2. Will always avoid showing a lone portrait image where possible.

## How it works

**Solution:** New `selectAssetsForDisplay()` function will determine what to show using the following heuristic.

1. If `splitview` is not enabled → show just the next image `[0]` in the queue.
2. If there is only one item in the queue  → return that one item.
3. If next image `[0]` is landscape → show it alone.
4. If next 2 images in the queue `[0] and [1]` are both portrait → pair both of them. i.e. return [0, 1]
5. **NEW:** If the first `[0]` is portrait, second `[1]` is landscape and third `[2]` is portrait → pair the first and third portrait images together. i.e. return [0, 2]
   - The middle landscape image will now be the tip of the queue for the next selection. 
6. **NEW** If first `[0]` is portrait, second `[1]` is landscape and third `[2]` is landscape → skip the lone portrait image and return the next one. i.e. return [1]
   - Whenever a new portrait image reaches the top of the queue, we will hit state `5` above, and then the first portrait image will be returned alongside the new one.
   - _What if we never get another portrait image_: Then eventually we will drain the queue and hit state `2` above. Only then will you get a lone portrait image.

Note: Videos are always treated as landscape in the algorithm above, this is because `isPortrait()` returns false for videos (existing logic). They're always shown alone regardless of their orientation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated photo navigation to use a candidate-based next/previous selection flow for more consistent results and improved multi-item pairing.
  * Enhanced orientation/layout logic to better detect portrait vs. landscape and choose display combinations accordingly.
  * Asset loading now consistently includes the persisted client identifier for reliable retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->