### PR TITLE
Add Exhaustive Shuffle Support for Albums

### DIFF
--- a/ImmichFrame.Core/Api/AssetListResponseDto.cs
+++ b/ImmichFrame.Core/Api/AssetListResponseDto.cs
@@ -1,0 +1,8 @@
+﻿namespace ImmichFrame.Core.Api
+{
+    public partial class AssetListResponseDto
+    {
+        public int AssetOffset { get; set; }
+        public List<AssetResponseDto>? Assets { get; set; }
+    }
+}

--- a/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Interfaces/IImmichFrameLogic.cs
@@ -5,8 +5,8 @@ namespace ImmichFrame.Core.Interfaces
 {
     public interface IImmichFrameLogic
     {
-        public Task<AssetResponseDto?> GetNextAsset();
-        public Task<IEnumerable<AssetResponseDto>> GetAssets();
+        public Task<AssetResponseDto?> GetNextAsset(IRequestContext requestContext);
+        public Task<IEnumerable<AssetResponseDto>> GetAssets(IRequestContext requestContext);
         public Task<AssetResponseDto> GetAssetInfoById(Guid assetId);
         public Task<IEnumerable<AlbumResponseDto>> GetAlbumInfoById(Guid assetId);
         public Task<(string fileName, string ContentType, Stream fileStream)> GetAsset(Guid id, AssetTypeEnum? assetType = null);
@@ -23,8 +23,8 @@ namespace ImmichFrame.Core.Interfaces
     public interface IAccountSelectionStrategy
     {
         void Initialize(IList<IAccountImmichFrameLogic> accounts);
-        Task<(IAccountImmichFrameLogic, AssetResponseDto)?> GetNextAsset();
-        Task<IEnumerable<(IAccountImmichFrameLogic, AssetResponseDto)>> GetAssets();
+        Task<(IAccountImmichFrameLogic, AssetResponseDto)?> GetNextAsset(IRequestContext requestContext);
+        Task<IEnumerable<(IAccountImmichFrameLogic, AssetResponseDto)>> GetAssets(IRequestContext requestContext);
         T ForAsset<T>(Guid assetId, Func<IAccountImmichFrameLogic, T> f);
     }
 }

--- a/ImmichFrame.Core/Interfaces/IRequestContext.cs
+++ b/ImmichFrame.Core/Interfaces/IRequestContext.cs
@@ -3,6 +3,6 @@ namespace ImmichFrame.Core.Interfaces
     public interface IRequestContext
     {
         int AssetOffset { get; set; }
-        int AssestShuffleRandom { get; set; }
+        int AssetShuffleRandom { get; set; }
     }
 }

--- a/ImmichFrame.Core/Interfaces/IRequestContext.cs
+++ b/ImmichFrame.Core/Interfaces/IRequestContext.cs
@@ -3,5 +3,6 @@ namespace ImmichFrame.Core.Interfaces
     public interface IRequestContext
     {
         int AssetOffset { get; set; }
+        int AssestShuffleRandom { get; set; }
     }
 }

--- a/ImmichFrame.Core/Interfaces/IRequestContext.cs
+++ b/ImmichFrame.Core/Interfaces/IRequestContext.cs
@@ -1,0 +1,7 @@
+namespace ImmichFrame.Core.Interfaces
+{
+    public interface IRequestContext
+    {
+        int AssetOffset { get; set; }
+    }
+}

--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -64,6 +64,7 @@
         public bool ImagePan { get; }
         public bool ImageFill { get; }
         public bool PlayAudio { get; }
+        public bool ExhaustiveAlbumShuffle { get; }
         public string Layout { get; }
         public string Language { get; }
 

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -24,14 +24,15 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
             keySelector: a => a,
             elementSelector: logicFactory
         );
+
         _accountSelectionStrategy.Initialize(_accountToDelegate.Values);
     }
 
-    public async Task<AssetResponseDto?> GetNextAsset() => (await _accountSelectionStrategy.GetNextAsset())?.ToAsset();
+    public async Task<AssetResponseDto?> GetNextAsset(IRequestContext requestContext) => (await _accountSelectionStrategy.GetNextAsset(requestContext))?.ToAsset();
 
 
-    public async Task<IEnumerable<AssetResponseDto>> GetAssets()
-        => (await _accountSelectionStrategy.GetAssets()).Shuffle().Select(it => it.ToAsset());
+    public async Task<IEnumerable<AssetResponseDto>> GetAssets(IRequestContext requestContext)
+        => (await _accountSelectionStrategy.GetAssets(requestContext)).Shuffle().Select(it => it.ToAsset());
 
 
     public Task<AssetResponseDto> GetAssetInfoById(Guid assetId)

--- a/ImmichFrame.Core/Logic/Pool/AggregatingAssetPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AggregatingAssetPool.cs
@@ -1,14 +1,16 @@
 using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Interfaces;
+
 
 namespace ImmichFrame.Core.Logic.Pool;
 
 public abstract class AggregatingAssetPool : IAssetPool
 {
     public abstract Task<long> GetAssetCount(CancellationToken ct = default);
-    protected abstract Task<AssetResponseDto?> GetNextAsset(CancellationToken ct);
+    protected abstract Task<AssetResponseDto?> GetNextAsset(IRequestContext requestContext, CancellationToken ct);
 
-    public Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default)
+    public Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, IRequestContext requestContext, CancellationToken ct = default)
     {
-        return IAssetPool.WaitAssets(requested, GetNextAsset, ct);
+        return IAssetPool.WaitAssets(requested, GetNextAsset, requestContext, ct);
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
@@ -1,5 +1,4 @@
 using ImmichFrame.Core.Api;
-using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
@@ -20,6 +19,6 @@ public class AlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSe
             }
         }
 
-        return albumAssets.Shuffle().ToList();
+        return albumAssets;
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AlbumAssetsPool.cs
@@ -1,4 +1,5 @@
 using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
@@ -19,6 +20,6 @@ public class AlbumAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSe
             }
         }
 
-        return albumAssets;
+        return albumAssets.Shuffle().ToList();
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/AllAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/AllAssetsPool.cs
@@ -20,7 +20,7 @@ public class AllAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSett
         return stats.Images;
     }
 
-    public async Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default)
+    public async Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, IRequestContext requestContext, CancellationToken ct = default)
     {
         var searchDto = new RandomSearchDto
         {

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -25,7 +25,7 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
 
         var assetsToReturn = allAssets.Skip(requestContext.AssetOffset).Take(requested);
 
-        requestContext.AssetOffset += requested;
+        requestContext.AssetOffset += assetsToReturn.Count();
         if (requestContext.AssetOffset >= totalCount)
         {
             requestContext.AssetOffset = 0;

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -22,9 +22,9 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
         }
 
         var orderValue = new Random(requestContext.AssetShuffleRandom);
-        var assetsToReturn = allAssets.OrderBy(_ => orderValue.Next()).Skip(requestContext.AssetOffset).Take(requested);
+        var assetsToReturn = allAssets.OrderBy(_ => orderValue.Next()).Skip(requestContext.AssetOffset).Take(requested).ToList();
 
-        requestContext.AssetOffset += assetsToReturn.Count();
+        requestContext.AssetOffset += assetsToReturn.Count;
         if (requestContext.AssetOffset >= totalCount)
         {
             requestContext.AssetOffset = 0;

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -21,7 +21,8 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
             requestContext.AssetOffset = 0;
         }
 
-        var assetsToReturn = allAssets.OrderBy(_ => requestContext.AssestShuffleRandom).Skip(requestContext.AssetOffset).Take(requested);
+        var orderValue = new Random(requestContext.AssetShuffleRandom);
+        var assetsToReturn = allAssets.OrderBy(_ => orderValue.Next()).Skip(requestContext.AssetOffset).Take(requested);
 
         requestContext.AssetOffset += assetsToReturn.Count();
         if (requestContext.AssetOffset >= totalCount)

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -16,7 +16,7 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
         var allAssets = await AllAssets(ct);
         var totalCount = allAssets.Count();
 
-        if (requestContext.AssetOffset >= totalCount)
+        if (requestContext.AssetOffset >= totalCount || requestContext.AssetOffset < 0)
         {
             requestContext.AssetOffset = 0;
         }

--- a/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/CachingApiAssetsPool.cs
@@ -6,8 +6,6 @@ namespace ImmichFrame.Core.Logic.Pool;
 
 public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichApi, IAccountSettings accountSettings) : IAssetPool
 {
-    private readonly Random _random = new();
-
     public async Task<long> GetAssetCount(CancellationToken ct = default)
     {
         return (await AllAssets(ct)).Count();
@@ -23,7 +21,7 @@ public abstract class CachingApiAssetsPool(IApiCache apiCache, ImmichApi immichA
             requestContext.AssetOffset = 0;
         }
 
-        var assetsToReturn = allAssets.Skip(requestContext.AssetOffset).Take(requested);
+        var assetsToReturn = allAssets.OrderBy(_ => requestContext.AssestShuffleRandom).Skip(requestContext.AssetOffset).Take(requested);
 
         requestContext.AssetOffset += assetsToReturn.Count();
         if (requestContext.AssetOffset >= totalCount)

--- a/ImmichFrame.Core/Logic/Pool/IAssetPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/IAssetPool.cs
@@ -1,15 +1,17 @@
 using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
 public interface IAssetPool
 {
     Task<long> GetAssetCount(CancellationToken ct = default);
-    Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, CancellationToken ct = default);
+    Task<IEnumerable<AssetResponseDto>> GetAssets(int requested, IRequestContext requestContext, CancellationToken ct = default);
 
     protected static async Task<IEnumerable<AssetResponseDto>> WaitAssets(
         int requested,
-        Func<CancellationToken, Task<AssetResponseDto?>> supplier,
+        Func<IRequestContext, CancellationToken, Task<AssetResponseDto?>> supplier,
+        IRequestContext requestContext,
         CancellationToken? cancellationToken = null)
     {
         //allow up to one minute
@@ -19,7 +21,7 @@ public interface IAssetPool
 
         for (var i = 0; i < requested; i++)
         {
-            var asset = await supplier(ct);
+            var asset = await supplier(requestContext, ct);
 
             if (asset != null)
             {

--- a/ImmichFrame.Core/Logic/Pool/MultiAssetPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MultiAssetPool.cs
@@ -1,5 +1,6 @@
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Helpers;
+using ImmichFrame.Core.Interfaces;
 
 namespace ImmichFrame.Core.Logic.Pool;
 
@@ -11,12 +12,12 @@ public class MultiAssetPool(IEnumerable<IAssetPool> delegates) : AggregatingAsse
         return (await Task.WhenAll(counts)).Sum();
     }
 
-    protected override async Task<AssetResponseDto?> GetNextAsset(CancellationToken ct)
+    protected override async Task<AssetResponseDto?> GetNextAsset(IRequestContext requestContext, CancellationToken ct)
     {
-        var pool = await delegates.ChooseOne(async @delegate=> await @delegate.GetAssetCount(ct));
-        
+        var pool = await delegates.ChooseOne(async @delegate => await @delegate.GetAssetCount(ct));
+
         if (pool == null) return null;
-        
-        return (await pool.GetAssets(1, ct)).FirstOrDefault();
+
+        return (await pool.GetAssets(1, requestContext, ct)).FirstOrDefault();
     }
 }

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -64,14 +64,14 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
         return new MultiAssetPool(pools);
     }
 
-    public async Task<AssetResponseDto?> GetNextAsset()
+    public async Task<AssetResponseDto?> GetNextAsset(IRequestContext requestContext)
     {
-        return (await _pool.GetAssets(1)).FirstOrDefault();
+        return (await _pool.GetAssets(1, requestContext)).FirstOrDefault();
     }
 
-    public Task<IEnumerable<AssetResponseDto>> GetAssets()
+    public Task<IEnumerable<AssetResponseDto>> GetAssets(IRequestContext requestContext)
     {
-        return _pool.GetAssets(25);
+        return _pool.GetAssets(25, requestContext);
     }
 
     public Task<AssetResponseDto> GetAssetInfoById(Guid assetId) => _immichApi.GetAssetInfoAsync(assetId, null);

--- a/ImmichFrame.Core/Services/RequestContextService.cs
+++ b/ImmichFrame.Core/Services/RequestContextService.cs
@@ -5,6 +5,6 @@ namespace ImmichFrame.Core.Services
     public class RequestContext : IRequestContext
     {
         public int AssetOffset { get; set; }
-        public int AssestShuffleRandom { get; set; }
+        public int AssetShuffleRandom { get; set; }
     }
 }

--- a/ImmichFrame.Core/Services/RequestContextService.cs
+++ b/ImmichFrame.Core/Services/RequestContextService.cs
@@ -5,5 +5,6 @@ namespace ImmichFrame.Core.Services
     public class RequestContext : IRequestContext
     {
         public int AssetOffset { get; set; }
+        public int AssestShuffleRandom { get; set; }
     }
 }

--- a/ImmichFrame.Core/Services/RequestContextService.cs
+++ b/ImmichFrame.Core/Services/RequestContextService.cs
@@ -1,0 +1,9 @@
+using ImmichFrame.Core.Interfaces;
+
+namespace ImmichFrame.Core.Services
+{
+    public class RequestContext : IRequestContext
+    {
+        public int AssetOffset { get; set; }
+    }
+}

--- a/ImmichFrame.WebApi.Tests/Resources/TestV1.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV1.json
@@ -8,6 +8,7 @@
     "ImagePan": true,
     "ImageFill": true,
     "PlayAudio": true,
+    "ExhaustiveAlbumShuffle": true,
     "Layout": "Layout_TEST",
     "DownloadImages": true,
     "ShowMemories": true,

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.json
@@ -35,6 +35,7 @@
     "ImagePan": true,
     "ImageFill": true,
     "PlayAudio": true,
+    "ExhaustiveAlbumShuffle": true,
     "Layout": "Layout_TEST"
   },
   "Accounts": [

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
@@ -34,6 +34,7 @@ General:
   ImagePan: true
   ImageFill: true
   PlayAudio: true
+  ExhaustiveAlbumShuffle: true
   Layout: Layout_TEST
 Accounts:
 - ImmichServerUrl: Account1.ImmichServerUrl_TEST

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -37,7 +37,7 @@ namespace ImmichFrame.WebApi.Controllers
         }
 
         [HttpGet(Name = "GetAssets")]
-        public async Task<AssetListResponseDto> GetAssets(string clientIdentifier = "", int assetOffset = 0)
+        public async Task<AssetListResponseDto> GetAssets(string clientIdentifier = "")
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Assets requested by '{sanitizedClientIdentifier}'", sanitizedClientIdentifier);

--- a/ImmichFrame.WebApi/Controllers/AssetController.cs
+++ b/ImmichFrame.WebApi/Controllers/AssetController.cs
@@ -26,19 +26,28 @@ namespace ImmichFrame.WebApi.Controllers
         private readonly IImmichFrameLogic _logic;
         private readonly IGeneralSettings _settings;
 
-        public AssetController(ILogger<AssetController> logger, IImmichFrameLogic logic, IGeneralSettings settings)
+        private readonly IRequestContext _requestContext;
+
+        public AssetController(ILogger<AssetController> logger, IImmichFrameLogic logic, IGeneralSettings settings, IRequestContext requestContext)
         {
             _logger = logger;
             _logic = logic;
             _settings = settings;
+            _requestContext = requestContext;
         }
 
         [HttpGet(Name = "GetAssets")]
-        public async Task<List<AssetResponseDto>> GetAssets(string clientIdentifier = "")
+        public async Task<AssetListResponseDto> GetAssets(string clientIdentifier = "", int assetOffset = 0)
         {
             var sanitizedClientIdentifier = clientIdentifier.SanitizeString();
             _logger.LogDebug("Assets requested by '{sanitizedClientIdentifier}'", sanitizedClientIdentifier);
-            return (await _logic.GetAssets()).ToList();
+
+            AssetListResponseDto response = new AssetListResponseDto();
+
+            response.Assets = (await _logic.GetAssets(_requestContext)).ToList();
+            response.AssetOffset = _requestContext.AssetOffset;
+
+            return response;
         }
 
         [HttpGet("{id}/AssetInfo", Name = "GetAssetInfo")]
@@ -94,7 +103,7 @@ namespace ImmichFrame.WebApi.Controllers
             const int maxAttempts = 10;
             for (int i = 0; i < maxAttempts; i++)
             {
-                var candidate = await _logic.GetNextAsset();
+                var candidate = await _logic.GetNextAsset(_requestContext);
                 if (candidate == null) break;
                 if (candidate.Type == AssetTypeEnum.IMAGE)
                 {

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -55,6 +55,7 @@ public class ServerSettingsV1 : IConfigSettable
     public bool ImagePan { get; set; } = false;
     public bool ImageFill { get; set; } = false;
     public bool PlayAudio { get; set; } = false;
+    public bool ExhaustiveAlbumShuffle { get; set; } = false;
     public string Layout { get; set; } = "splitview";
 }
 
@@ -86,6 +87,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ShowArchived => _delegate.ShowArchived;
         public bool ShowVideos => _delegate.ShowVideos;
         public bool PlayAudio => _delegate.PlayAudio;
+        public bool ExhaustiveAlbumShuffle => _delegate.ExhaustiveAlbumShuffle;
         public int? ImagesFromDays => _delegate.ImagesFromDays;
         public DateTime? ImagesFromDate => _delegate.ImagesFromDate;
         public DateTime? ImagesUntilDate => _delegate.ImagesUntilDate;
@@ -133,6 +135,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool ImagePan => _delegate.ImagePan;
         public bool ImageFill => _delegate.ImageFill;
         public bool PlayAudio => _delegate.PlayAudio;
+        public bool ExhaustiveAlbumShuffle => _delegate.ExhaustiveAlbumShuffle;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
 

--- a/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
+++ b/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
@@ -13,14 +13,14 @@ namespace ImmichFrame.WebApi.Helpers
 
         public async Task InvokeAsync(HttpContext context, IRequestContext requestContext)
         {
+            // assetOffest
             if (context.Request.Query.TryGetValue("assetOffset", out var assetOffset))
             {
                 string value = assetOffset.ToString();
 
                 if (value != null && value.Length > 0)
                 {
-                    int number;
-                    bool success = int.TryParse(value, out number);
+                    bool success = int.TryParse(value, out int number);
                     if (success)
                     {
                         requestContext.AssetOffset = number;
@@ -33,6 +33,29 @@ namespace ImmichFrame.WebApi.Helpers
                 else
                 {
                     requestContext.AssetOffset = 0;
+                }
+            }
+
+            // assestShuffleRandom
+            if (context.Request.Query.TryGetValue("assestShuffleRandom", out var assestShuffleRandom))
+            {
+                string value = assestShuffleRandom.ToString();
+
+                if (value != null && value.Length > 0)
+                {
+                    bool success = int.TryParse(value, out int number);
+                    if (success)
+                    {
+                        requestContext.AssestShuffleRandom = number;
+                    }
+                    else
+                    {
+                        requestContext.AssestShuffleRandom = 0;
+                    }
+                }
+                else
+                {
+                    requestContext.AssestShuffleRandom = 0;
                 }
             }
 

--- a/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
+++ b/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
@@ -16,9 +16,23 @@ namespace ImmichFrame.WebApi.Helpers
             if (context.Request.Query.TryGetValue("assetOffset", out var assetOffset))
             {
                 string value = assetOffset.ToString();
+
                 if (value != null && value.Length > 0)
                 {
-                    requestContext.AssetOffset = int.Parse(value);
+                    int number;
+                    bool success = int.TryParse(value, out number);
+                    if (success)
+                    {
+                        requestContext.AssetOffset = number;
+                    }
+                    else
+                    {
+                        requestContext.AssetOffset = 0;
+                    }
+                }
+                else
+                {
+                    requestContext.AssetOffset = 0;
                 }
             }
 

--- a/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
+++ b/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
@@ -13,7 +13,7 @@ namespace ImmichFrame.WebApi.Helpers
 
         public async Task InvokeAsync(HttpContext context, IRequestContext requestContext)
         {
-            // assetOffest
+            // assetOffset
             if (context.Request.Query.TryGetValue("assetOffset", out var assetOffset))
             {
                 string value = assetOffset.ToString();

--- a/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
+++ b/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
@@ -1,0 +1,28 @@
+using ImmichFrame.Core.Interfaces;
+
+namespace ImmichFrame.WebApi.Helpers
+{
+    public class RequestContextMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public RequestContextMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context, IRequestContext requestContext)
+        {
+            if (context.Request.Query.TryGetValue("assetOffset", out var assetOffset))
+            {
+                string value = assetOffset.ToString();
+                if (value != null && value.Length > 0)
+                {
+                    requestContext.AssetOffset = int.Parse(value);
+                }
+            }
+
+            await _next(context);
+        }
+    }
+}

--- a/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
+++ b/ImmichFrame.WebApi/Helpers/RequestContextMiddleware.cs
@@ -36,26 +36,26 @@ namespace ImmichFrame.WebApi.Helpers
                 }
             }
 
-            // assestShuffleRandom
-            if (context.Request.Query.TryGetValue("assestShuffleRandom", out var assestShuffleRandom))
+            // assetShuffleRandom
+            if (context.Request.Query.TryGetValue("assestShuffleRandom", out var assetShuffleRandom))
             {
-                string value = assestShuffleRandom.ToString();
+                string value = assetShuffleRandom.ToString();
 
                 if (value != null && value.Length > 0)
                 {
                     bool success = int.TryParse(value, out int number);
                     if (success)
                     {
-                        requestContext.AssestShuffleRandom = number;
+                        requestContext.AssetShuffleRandom = number;
                     }
                     else
                     {
-                        requestContext.AssestShuffleRandom = 0;
+                        requestContext.AssetShuffleRandom = 0;
                     }
                 }
                 else
                 {
-                    requestContext.AssestShuffleRandom = 0;
+                    requestContext.AssetShuffleRandom = 0;
                 }
             }
 

--- a/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
+++ b/ImmichFrame.WebApi/Models/ClientSettingsDto.cs
@@ -30,6 +30,7 @@ public class ClientSettingsDto
     public bool ImagePan { get; set; }
     public bool ImageFill { get; set; }
     public bool PlayAudio { get; set; }
+    public bool ExhaustiveAlbumShuffle { get; set; }
     public string Layout { get; set; }
     public string Language { get; set; }
 
@@ -62,6 +63,7 @@ public class ClientSettingsDto
         dto.ImagePan = generalSettings.ImagePan;
         dto.ImageFill = generalSettings.ImageFill;
         dto.PlayAudio = generalSettings.PlayAudio;
+        dto.ExhaustiveAlbumShuffle = generalSettings.ExhaustiveAlbumShuffle;
         dto.Layout = generalSettings.Layout;
         dto.Language = generalSettings.Language;
         return dto;

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -63,6 +63,7 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public bool ImagePan { get; set; } = false;
     public bool ImageFill { get; set; } = false;
     public bool PlayAudio { get; set; } = false;
+    public bool ExhaustiveAlbumShuffle { get; set; } = false;
     public string Layout { get; set; } = "splitview";
     public int RenewImagesDuration { get; set; } = 30;
     public List<string> Webcalendars { get; set; } = new();

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -1,10 +1,12 @@
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Services;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authentication;
 using System.Reflection;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
+using ImmichFrame.WebApi.Helpers;
 using ImmichFrame.WebApi.Helpers.Config;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -68,6 +70,9 @@ builder.Services.AddTransient<Func<IAccountSettings, IAccountImmichFrameLogic>>(
 
 builder.Services.AddSingleton<IImmichFrameLogic, MultiImmichFrameLogicDelegate>();
 
+// Register Context Service
+builder.Services.AddScoped<IRequestContext, RequestContext>();
+
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
@@ -104,6 +109,7 @@ if (app.Environment.IsDevelopment())
 
 // app.UseHttpsRedirection();
 app.UseMiddleware<CustomAuthenticationMiddleware>();
+app.UseMiddleware<RequestContextMiddleware>();
 
 app.UseAuthentication();
 app.UseAuthorization();

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -47,6 +47,7 @@
 	let authError: boolean = $state(false);
 	let errorMessage: string = $state('');
 	let assetOffset: number = 0;
+	let assestShuffleRandom: number = Math.floor(Math.random());
 	let assetsState: AssetsState = $state({
 		assets: [],
 		error: false,
@@ -132,7 +133,8 @@
 		try {
 			let assetRequest = await api.getAssets({
 				clientIdentifier: $clientIdentifierStore,
-				assetOffset: assetOffset
+				assetOffset: assetOffset,
+				assestShuffleRandom: assestShuffleRandom
 			});
 
 			if (assetRequest.status != 200) {

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -46,6 +46,7 @@
 	let infoVisible: boolean = $state(false);
 	let authError: boolean = $state(false);
 	let errorMessage: string = $state('');
+	let assetOffset: number = 0;
 	let assetsState: AssetsState = $state({
 		assets: [],
 		error: false,
@@ -129,7 +130,10 @@
 
 	async function loadAssets() {
 		try {
-			let assetRequest = await api.getAssets();
+			let assetRequest = await api.getAssets({
+				clientIdentifier: undefined,
+				assetOffset: assetOffset
+			});
 
 			if (assetRequest.status != 200) {
 				if (assetRequest.status == 401) {
@@ -140,9 +144,11 @@
 			}
 
 			error = false;
-			assetBacklog = assetRequest.data.filter(
+			assetBacklog = assetRequest.data.assets.filter(
 				(asset) => isImageAsset(asset) || isVideoAsset(asset)
 			);
+
+			assetOffset = assetRequest.data.assetOffset;
 		} catch {
 			error = true;
 		}

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -47,7 +47,7 @@
 	let authError: boolean = $state(false);
 	let errorMessage: string = $state('');
 	let assetOffset: number = 0;
-	let assestShuffleRandom: number = Math.floor(Math.random());
+	let assetShuffleRandom: number = Math.floor(Math.random() * 1000000);
 	let assetsState: AssetsState = $state({
 		assets: [],
 		error: false,
@@ -134,7 +134,7 @@
 			let assetRequest = await api.getAssets({
 				clientIdentifier: $clientIdentifierStore,
 				assetOffset: assetOffset,
-				assestShuffleRandom: assestShuffleRandom
+				assestShuffleRandom: assetShuffleRandom
 			});
 
 			if (assetRequest.status != 200) {

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -131,7 +131,7 @@
 	async function loadAssets() {
 		try {
 			let assetRequest = await api.getAssets({
-				clientIdentifier: undefined,
+				clientIdentifier: $clientIdentifierStore,
 				assetOffset: assetOffset
 			});
 

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -227,16 +227,18 @@ export type IWeather = {
     description?: string | null;
     iconId?: string | null;
 };
-export function getAssets({ clientIdentifier, assetOffset }: {
+export function getAssets({ clientIdentifier, assetOffset, assestShuffleRandom }: {
    clientIdentifier?: string;
    assetOffset?: number;
+   assestShuffleRandom?: number;
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
         data: AssetListResponseDto;
     }>(`/api/Asset${QS.query(QS.explode({
         clientIdentifier,
-        assetOffset
+        assetOffset,
+        assestShuffleRandom
     }))}`, {
         ...opts
     });

--- a/immichFrame.Web/src/lib/immichFrameApi.ts
+++ b/immichFrame.Web/src/lib/immichFrameApi.ts
@@ -102,6 +102,10 @@ export type TagResponseDto = {
 };
 export type AssetTypeEnum = 0 | 1 | 2 | 3;
 export type AssetVisibility = 0 | 1 | 2 | 3;
+export type AssetListResponseDto = {
+    assetOffset: number;
+    assets: AssetResponseDto[];
+};
 export type AssetResponseDto = {
     immichServerUrl?: string | null;
     checksum: string;
@@ -223,14 +227,16 @@ export type IWeather = {
     description?: string | null;
     iconId?: string | null;
 };
-export function getAssets({ clientIdentifier }: {
-    clientIdentifier?: string;
+export function getAssets({ clientIdentifier, assetOffset }: {
+   clientIdentifier?: string;
+   assetOffset?: number;
 } = {}, opts?: Oazapfts.RequestOpts) {
     return oazapfts.fetchJson<{
         status: 200;
-        data: AssetResponseDto[];
+        data: AssetListResponseDto;
     }>(`/api/Asset${QS.query(QS.explode({
-        clientIdentifier
+        clientIdentifier,
+        assetOffset
     }))}`, {
         ...opts
     });


### PR DESCRIPTION
This PR is a potential solution to the exhaustive shuffle (https://github.com/immichFrame/ImmichFrame/issues/438) issue.

The main changes here are that we now shuffle the assets once and cache them (so we'll fetch/shuffle daily, without restarts), and the web client keeps track of an offset position, which is used by the API to determine which section/slice of the assets to return to the client. The API returns a new offset with each response, so the web client can stay ignorant of the assets outside of the 25 that are currently returned with each request. The offset correctly rolls over to 0 if it exceeds the length of the assets.

One caveat here is that every client will get the images in exactly the same order. We could add a random offset to the first asset fetch (say if it's a negative number), so multiple clients don't show the exact same images if they connect at the same time.
Another is that we now pass a `RequestContext` around, which is how we know about the offset from each client. I believe in the future this might prove useful if there is ever a desire for client-side configurations, or other similar behaviour.

I have added an `ExhaustiveAlbumShuffle` setting, but I have not used it, as I'm not sure if this needs to be behind a setting, or if this new behaviour as the default is acceptable. Also, using settings inside of the Pools was potentially not an easy lift and I didn't want this PR to get any bigger than it already is without getting some feedback.

I have been testing on an album of almost 600 assets, mixed pictures and videos, and it's been good.

Please let me know your thoughts, as I am very much looking forward to something like this to prevent seeing the same images multiple times, and some almost never.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request-scoped context for asset retrieval (offset and shuffle seed), deterministic paging, and API now returns assets plus assetOffset while accepting offset/shuffle query parameters.
  * New ExhaustiveAlbumShuffle configuration exposed to client and server.
  * Middleware and service wiring populate request context from query parameters.

* **Tests**
  * Test scaffolding updated to exercise the context-aware asset retrieval API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->