### PR TITLE
avoid duplicates in split view

### DIFF
--- a/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
@@ -1,0 +1,111 @@
+using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Logic.QueueMutator;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace ImmichFrame.Core.Tests.Logic.QueueMutator;
+
+[TestFixture]
+public class DuplicateAvoidingQueueMutatorTests
+{
+    private IQueueMutator<AssetResponseDto> _queueMutator;
+
+    [SetUp]
+    public void Setup()
+    {
+        _queueMutator = new DuplicateAvoidingQueueMutator(2, new NullLogger<DuplicateAvoidingQueueMutator>());
+    }
+    
+    [Test]
+    public void Mutate_NoItems_Succeeds()
+    {
+        IEnumerable<AssetResponseDto> result = [new()];
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate([]));
+        Assert.That(result, Is.Empty);
+    }
+    
+    [Test]
+    public void Mutate_NoDuplicates_NoChange()
+    {
+        List<AssetResponseDto> original = [
+            new(){Id = "aap"},
+            new(){Id = "noot"},
+            new(){Id = "mies"},
+            new(){Id = "aardappel"},
+        ];
+        IEnumerable<AssetResponseDto> result = [];
+        IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
+        Assert.That(result, Is.EquivalentTo(original));
+    }
+    
+    [Test]
+    public void Mutate_SeparatedDuplicates_NoChange()
+    {
+        List<AssetResponseDto> original = [
+            new(){Id = "aap"},
+            new(){Id = "mies"},
+            new(){Id = "noot"},
+            new(){Id = "mies"},
+            new(){Id = "aardappel"},
+            new(){Id = "mies"},
+        ];
+        IEnumerable<AssetResponseDto> result = [];
+        IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
+        Assert.That(result, Is.EquivalentTo(original));
+    }
+    
+    [Test]
+    public void Mutate_AdjacentDuplicates_ShouldSeperate()
+    {
+        List<AssetResponseDto> original = [
+            new(){Id = "aap"},
+            new(){Id = "aap"},
+            new(){Id = "noot"},
+            new(){Id = "mies"},
+            new(){Id = "aardappel"},
+        ];
+        IEnumerable<AssetResponseDto> result = [];
+        IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
+        Assert.That(result, Is.Not.EqualTo(original));
+    }
+    [Test]
+    public void Mutate_AdjacentDuplicates_differentBatch_NoChange()
+    {
+        List<AssetResponseDto> original = [
+            new(){Id = "aap"},
+            new(){Id = "noot"},
+            new(){Id = "noot"},
+            new(){Id = "mies"},
+            new(){Id = "aardappel"},
+        ];
+        IEnumerable<AssetResponseDto> result = [];
+        IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
+        Assert.That(result, Is.EqualTo(original));
+    }
+    [Test]
+    public void Mutate_LandscapeDuplicates_adjacent_NoChange()
+    {
+        List<AssetResponseDto> original = [
+            new(){Id = "aap"},
+            new(){Id = "peter"},
+            new(){Id = "noot", ExifInfo =new(){Orientation = "1", ExifImageWidth = 200, ExifImageHeight = 100}},
+            new(){Id = "noot", ExifInfo =new(){Orientation = "1", ExifImageWidth = 200, ExifImageHeight = 100}},
+            new(){Id = "mies"},
+            new(){Id = "aardappel"},
+        ];
+        IEnumerable<AssetResponseDto> result = [];
+        IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
+        
+        Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
+        Assert.That(result, Is.EqualTo(original));
+    }
+}

--- a/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
@@ -38,7 +38,7 @@ public class DuplicateAvoidingQueueMutatorTests
         IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
         
         Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
-        Assert.That(result, Is.EquivalentTo(original));
+        Assert.That(result, Is.EqualTo(original));
     }
     
     [Test]
@@ -56,7 +56,7 @@ public class DuplicateAvoidingQueueMutatorTests
         IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
         
         Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
-        Assert.That(result, Is.EquivalentTo(original));
+        Assert.That(result, Is.EqualTo(original));
     }
     
     [Test]
@@ -73,7 +73,11 @@ public class DuplicateAvoidingQueueMutatorTests
         IEnumerable<AssetResponseDto> input = new List<AssetResponseDto>(original);
         
         Assert.DoesNotThrow(() => result = _queueMutator.Mutate(input));
-        Assert.That(result, Is.Not.EqualTo(original));
+        var assetResponseDtos = result as AssetResponseDto[] ?? result.ToArray();
+        for(int i = 0; i < assetResponseDtos.Length - 1; i++)
+        {
+            Assert.That(assetResponseDtos.ElementAt(i).Id, Is.Not.EqualTo(assetResponseDtos.ElementAt(i + 1).Id));
+        }
     }
     [Test]
     public void Mutate_AdjacentDuplicates_differentBatch_NoChange()

--- a/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/QueueMutator/DuplicateAvoidingQueueMutatorTests.cs
@@ -60,7 +60,7 @@ public class DuplicateAvoidingQueueMutatorTests
     }
     
     [Test]
-    public void Mutate_AdjacentDuplicates_ShouldSeperate()
+    public void Mutate_AdjacentDuplicates_ShouldSeparate()
     {
         List<AssetResponseDto> original = [
             new(){Id = "aap"},

--- a/ImmichFrame.Core/Helpers/ImageHelper.cs
+++ b/ImmichFrame.Core/Helpers/ImageHelper.cs
@@ -18,9 +18,9 @@ namespace ImmichFrame.Core.Helpers
         public static double GetAspectRatioFloat(double width, double height)
         {
             if (width <= 0 || height <= 0)
-                throw new ArgumentException("Width and height must be positive integers.");
+                throw new ArgumentException("Width and height must be positive.");
         
-            return (double)width / height;
+            return width / height;
         }
 
         public static bool IsLandscape(double exifWidth, double exifHeight, string exifOrientation)

--- a/ImmichFrame.Core/Helpers/ImageHelper.cs
+++ b/ImmichFrame.Core/Helpers/ImageHelper.cs
@@ -14,5 +14,40 @@ namespace ImmichFrame.Core.Helpers
 
             return new MemoryStream(binData);
         }
+        
+        public static double GetAspectRatioFloat(double width, double height)
+        {
+            if (width <= 0 || height <= 0)
+                throw new ArgumentException("Width and height must be positive integers.");
+        
+            return (double)width / height;
+        }
+
+        public static bool IsLandscape(double exifWidth, double exifHeight, string exifOrientation)
+        {
+            double width;
+            double height;
+            if (exifOrientation == "1" 
+                || exifOrientation == "2"
+                || exifOrientation == "3"
+                || exifOrientation == "4")
+            {
+                width = exifWidth;
+                height = exifHeight;
+            }else if (exifOrientation == "5" 
+                      || exifOrientation == "6"
+                      || exifOrientation == "7"
+                      || exifOrientation == "8")
+            {
+                height = exifWidth;
+                width = exifHeight;
+            }
+            else
+            {
+                throw new ArgumentException(nameof(exifOrientation));
+            }
+
+            return GetAspectRatioFloat(width, height) > 1;
+        }
     }
 }

--- a/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
+++ b/ImmichFrame.Core/Logic/MultiImmichFrameLogicDelegate.cs
@@ -2,6 +2,7 @@ using System.Collections.Frozen;
 using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Helpers;
 using ImmichFrame.Core.Interfaces;
+using ImmichFrame.Core.Logic.QueueMutator;
 using ImmichFrame.Core.Models;
 using Microsoft.Extensions.Logging;
 
@@ -13,13 +14,15 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
     private readonly IServerSettings _serverSettings;
     private readonly IAccountSelectionStrategy _accountSelectionStrategy;
     private readonly ILogger<MultiImmichFrameLogicDelegate> _logger;
+    private readonly IQueueMutator<AssetResponseDto> _queueMutator;
 
     public MultiImmichFrameLogicDelegate(IServerSettings serverSettings,
         Func<IAccountSettings, IAccountImmichFrameLogic> logicFactory, ILogger<MultiImmichFrameLogicDelegate> logger,
-        IAccountSelectionStrategy accountSelectionStrategy)
+        IAccountSelectionStrategy accountSelectionStrategy, IQueueMutator<AssetResponseDto> queueMutator)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _accountSelectionStrategy = accountSelectionStrategy;
+        _queueMutator = queueMutator;
         _serverSettings = serverSettings;
         _accountToDelegate = serverSettings.Accounts.ToFrozenDictionary(
             keySelector: a => a,
@@ -32,7 +35,7 @@ public class MultiImmichFrameLogicDelegate : IImmichFrameLogic
 
 
     public async Task<IEnumerable<AssetResponseDto>> GetAssets()
-        => (await _accountSelectionStrategy.GetAssets()).Shuffle().Select(it => it.ToAsset());
+        => _queueMutator.Mutate((await _accountSelectionStrategy.GetAssets()).Select(it => it.ToAsset()));
 
 
     public Task<AssetResponseDto> GetAssetInfoById(Guid assetId)

--- a/ImmichFrame.Core/Logic/QueueMutator/DuplicateAvoidingQueueMutator.cs
+++ b/ImmichFrame.Core/Logic/QueueMutator/DuplicateAvoidingQueueMutator.cs
@@ -1,0 +1,69 @@
+using ImmichFrame.Core.Api;
+using ImmichFrame.Core.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace ImmichFrame.Core.Logic.QueueMutator;
+
+public class DuplicateAvoidingQueueMutator: QueueMutatorBase<AssetResponseDto>
+{
+    private readonly int _batchSize;
+    private readonly ILogger<DuplicateAvoidingQueueMutator> _logger;
+
+    public DuplicateAvoidingQueueMutator(int batchSize, ILogger<DuplicateAvoidingQueueMutator> logger)
+    {
+        if(batchSize <= 0) throw new ArgumentException("Batch size must be greater than 0", nameof(batchSize));
+        _batchSize = batchSize;
+        _logger = logger;
+    }
+    public override IEnumerable<AssetResponseDto> Mutate(IEnumerable<AssetResponseDto> source)
+    {
+        var remaining = new Queue<AssetResponseDto>(source);
+        List<AssetResponseDto> result = new(remaining.Count);
+        var batch = new List<AssetResponseDto>(_batchSize);
+
+        int consecutiveDuplicates = 0;
+        while (remaining.Count > 0)
+        {
+            var currentItem = remaining.Dequeue();
+
+            bool landscape = false;
+            try
+            {
+
+                landscape = ImageHelper.IsLandscape(currentItem.ExifInfo.ExifImageWidth!.Value,
+                    currentItem.ExifInfo.ExifImageHeight!.Value, currentItem.ExifInfo.Orientation);
+            }
+            catch
+            {
+                _logger.LogWarning("Failed to determine orientation for asset {AssetId}, defaulting to portrait", currentItem.Id);
+            }
+
+            
+            if (!landscape && batch.Any(x => x.Id == currentItem.Id))
+            {
+                remaining.Enqueue(currentItem);
+                consecutiveDuplicates++;
+                // no other items to process, break to avoid infinite loop
+                if (consecutiveDuplicates >= remaining.Count) break;
+                continue;
+            }
+
+            batch.Add(currentItem);
+
+            if (batch.Count >= _batchSize)
+            {
+                result.AddRange(batch);
+                batch.Clear();
+            }
+
+            consecutiveDuplicates = 0;
+        }
+
+        if (batch.Count > 0)
+        {
+            result.AddRange(batch);
+        }
+
+        return Next?.Mutate(result) ?? result;
+    }
+}

--- a/ImmichFrame.Core/Logic/QueueMutator/IQueueMutator.cs
+++ b/ImmichFrame.Core/Logic/QueueMutator/IQueueMutator.cs
@@ -1,0 +1,10 @@
+using System.Diagnostics.Contracts;
+
+namespace ImmichFrame.Core.Logic.QueueMutator;
+
+public interface IQueueMutator<T>
+{
+    [Pure]
+    IEnumerable<T> Mutate(IEnumerable<T> source);
+    void SetNext(IQueueMutator<T> next);
+}

--- a/ImmichFrame.Core/Logic/QueueMutator/QueueMutatorBase.cs
+++ b/ImmichFrame.Core/Logic/QueueMutator/QueueMutatorBase.cs
@@ -1,0 +1,13 @@
+namespace ImmichFrame.Core.Logic.QueueMutator;
+
+public abstract class QueueMutatorBase<T>: IQueueMutator<T>
+{
+    protected IQueueMutator<T>? Next;
+
+    public abstract IEnumerable<T> Mutate(IEnumerable<T> source);
+
+    public void SetNext(IQueueMutator<T> next)
+    {
+        Next = next;
+    }
+}

--- a/ImmichFrame.Core/Logic/QueueMutator/RandomQueueMutator.cs
+++ b/ImmichFrame.Core/Logic/QueueMutator/RandomQueueMutator.cs
@@ -1,0 +1,11 @@
+namespace ImmichFrame.Core.Logic.QueueMutator;
+
+public class RandomQueueMutator<T>: QueueMutatorBase<T>
+{
+    private readonly Random _random = new();
+    public override IEnumerable<T> Mutate(IEnumerable<T> source)
+    {
+        var result = source.OrderBy(_ => _random.Next());
+        return Next?.Mutate(result) ?? result;
+    }
+}

--- a/ImmichFrame.WebApi/Program.cs
+++ b/ImmichFrame.WebApi/Program.cs
@@ -3,9 +3,12 @@ using ImmichFrame.Core.Interfaces;
 using ImmichFrame.WebApi.Models;
 using Microsoft.AspNetCore.Authentication;
 using System.Reflection;
+using ImmichFrame.Core.Api;
 using ImmichFrame.Core.Logic;
 using ImmichFrame.Core.Logic.AccountSelection;
+using ImmichFrame.Core.Logic.QueueMutator;
 using ImmichFrame.WebApi.Helpers.Config;
+using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 var builder = WebApplication.CreateBuilder(args);
 //log the version number
@@ -72,6 +75,13 @@ builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddTransient<IQueueMutator<AssetResponseDto>>(x =>
+{
+    var mutator = new RandomQueueMutator<AssetResponseDto>();
+    mutator.SetNext(new DuplicateAvoidingQueueMutator(2, x.GetService<ILogger<DuplicateAvoidingQueueMutator>>()!));
+    return mutator;
+});
 
 builder.Services.AddAuthorization(options => { options.AddPolicy("AllowAnonymous", policy => policy.RequireAssertion(context => true)); });
 


### PR DESCRIPTION
server-side alternative to: https://github.com/immichFrame/ImmichFrame/pull/612

# summary
On my immich frame instance I mainly want to show memories which there are not a whole lot of and I noticed that the side by side view sometimes shows duplicates. I don't think it should be that way, so i've implemented a server-side chain  class that can manipulate queues (in this case for removing duplicates) and can be expanded to fit other que manipulation usecases.

# side effects
the amount of times only one portrait image is show was higher during testing because duplicates are moved to the back of the queue. I think this can best be fixed by adding another implementation of QueueManipulator that tries to optimize for this but perhaps it is best to leave that for another time.

# issues
I saw someone mention this in: https://github.com/immichFrame/ImmichFrame/issues/464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue-based asset processing with randomized ordering and avoidance of consecutive portrait-image duplicates
  * Image orientation detection to classify assets as landscape or portrait from EXIF metadata

* **Tests**
  * Added tests validating mutation behavior for empty inputs, non-duplicates, separated/adjacent duplicates, batch boundaries, and orientation-sensitive cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->