### PR TITLE
Show shared albums

### DIFF
--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -6,8 +6,7 @@
         {
             BaseUrl = url + "/api";
             _httpClient = httpClient;
-            _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
-            
+            _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);            
         }
 
         public async Task<FileResponse> PlayAssetVideoWithRangeAsync(Guid id, string rangeHeader, CancellationToken cancellationToken = default)

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -6,7 +6,7 @@
         {
             BaseUrl = url + "/api";
             _httpClient = httpClient;
-            _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);            
+            _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
         }
 
         public async Task<FileResponse> PlayAssetVideoWithRangeAsync(Guid id, string rangeHeader, CancellationToken cancellationToken = default)

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -45,11 +45,24 @@
         {
             var url = urlBuilder.ToString();
 
-            // ensure every call to the albums endpoint includes shared content
-            if (url.Contains("/albums/") && !url.Contains("shared=true"))
+            var parts = url.Split('?', 2);
+            var path = parts[0];
+            var query = parts.Length > 1 ? parts[1] : string.Empty;
+
+            var isAlbumsEndpoint = path.EndsWith("/albums", StringComparison.OrdinalIgnoreCase) || path.Contains("/albums/", StringComparison.OrdinalIgnoreCase);
+
+            if (isAlbumsEndpoint)
             {
-                string separator = url.Contains("?") ? "&" : "?";
-                urlBuilder.Append($"{separator}shared=true");
+                var hasSharedKey = query
+                    .Split('&', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(p => p.Split('=', 2)[0])
+                    .Any(k => string.Equals(k, "shared", StringComparison.OrdinalIgnoreCase));
+
+                if (!hasSharedKey)
+                {
+                    string separator = query.Length > 0 ? "&" : "?";
+                    urlBuilder.Append($"{separator}shared=true");
+                }
             }
         }
     }

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -7,6 +7,7 @@
             BaseUrl = url + "/api";
             _httpClient = httpClient;
             _settings = new Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+            
         }
 
         public async Task<FileResponse> PlayAssetVideoWithRangeAsync(Guid id, string rangeHeader, CancellationToken cancellationToken = default)
@@ -40,6 +41,17 @@
             var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
             response.Dispose();
             throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
+        }
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder)
+        {
+            var url = urlBuilder.ToString();
+
+            // ensure every call to the albums endpoint includes shared content
+            if (url.Contains("/albums/") && !url.Contains("shared=true"))
+            {
+                string separator = url.Contains("?") ? "&" : "?";
+                urlBuilder.Append($"{separator}shared=true");
+            }
         }
     }
 }


### PR DESCRIPTION
closes #625 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Album-related API requests now automatically include the required query parameter for shared albums when it’s not already present.
  * Detection handles existing query strings and recognizes the parameter regardless of case, preserving other query parameters and separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->