### PR TITLE
fix: Memories date

### DIFF
--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -9,7 +9,7 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
 {
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
-        var searchDate = new DateTimeOffset(DateTime.SpecifyKind(DateTime.Today, DateTimeKind.Utc), TimeSpan.Zero);
+        var searchDate = DateTimeOffset.Now;
         var memories = await immichApi.SearchMemoriesAsync(searchDate, null, null, null, ct);
 
         var memoryAssets = new List<AssetResponseDto>();


### PR DESCRIPTION
Closes #631 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory search date calculation to properly handle current time and timezone information, replacing the previous UTC-based timestamp approach. This ensures more accurate date-based memory retrieval and anniversary date calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->