### PR TITLE
Fix: Add timezone offset to Immich memories "for" query parameter

### DIFF
--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -41,5 +41,49 @@
             response.Dispose();
             throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
         }
+
+        // NSwag serializes DateTimeOffset query parameters with the "s" format, which drops the
+        // timezone offset (e.g. "2026-07-03T14:30:00"). Newer Immich versions validate these
+        // parameters as full ISO 8601 datetimes and reject any value without a timezone, causing a
+        // 400 on the memories endpoints ("for" parameter). Re-append the offset before sending.
+        // Only the "for" query parameter is affected; date filters for search go through the JSON
+        // body, which Newtonsoft already serializes with an offset.
+        partial void PrepareRequest(HttpClient client, HttpRequestMessage request, System.Text.StringBuilder urlBuilder)
+        {
+            EnsureTimezoneOffset(urlBuilder, "for");
+        }
+
+        private static void EnsureTimezoneOffset(System.Text.StringBuilder urlBuilder, string parameterName)
+        {
+            var url = urlBuilder.ToString();
+            var token = parameterName + "=";
+
+            var idx = url.IndexOf("?" + token, StringComparison.Ordinal);
+            if (idx < 0) idx = url.IndexOf("&" + token, StringComparison.Ordinal);
+            if (idx < 0) return;
+
+            var valueStart = idx + 1 + token.Length;
+            var valueEnd = url.IndexOf('&', valueStart);
+            if (valueEnd < 0) valueEnd = url.Length;
+
+            var encodedValue = url.Substring(valueStart, valueEnd - valueStart);
+            var rawValue = Uri.UnescapeDataString(encodedValue);
+
+            // Only rewrite values that look like a datetime; leave anything else untouched.
+            // The original offset is already lost at this point (stripped by "s"), so we re-infer it
+            // with AssumeLocal, i.e. the machine's local offset. This is correct for the only caller
+            // today (SearchMemoriesAsync with DateTimeOffset.Now). If a caller ever passes a value
+            // with a different offset (e.g. UTC), it would be normalized to the local offset here.
+            if (!DateTimeOffset.TryParse(rawValue, System.Globalization.CultureInfo.InvariantCulture,
+                    System.Globalization.DateTimeStyles.AssumeLocal, out var value))
+                return;
+
+            var fixedValue = Uri.EscapeDataString(
+                value.ToString("yyyy-MM-ddTHH:mm:sszzz", System.Globalization.CultureInfo.InvariantCulture));
+            if (fixedValue == encodedValue) return;
+
+            urlBuilder.Remove(valueStart, valueEnd - valueStart);
+            urlBuilder.Insert(valueStart, fixedValue);
+        }
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -10,6 +10,8 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var searchDate = DateTimeOffset.Now;
+        // Immich requires the "for" parameter to carry a timezone offset. NSwag strips it during
+        // query serialization, so it is re-added in ImmichApi.PrepareRequest (see EnsureTimezoneOffset).
         var memories = await immichApi.SearchMemoriesAsync(searchDate, null, null, null, null, null, ct);
 
         var memoryAssets = new List<AssetResponseDto>();


### PR DESCRIPTION
Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date-based requests so timezone offsets are preserved, improving accuracy for time-sensitive results across different locales.
  * Prevented query values from being altered in ways that could cause unexpected filtering or missed items.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->