### PR TITLE
chore: gitignore '.@__thumb': qnap thumbnail cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,9 @@ $RECYCLE.BIN/
 ## Ignore Settings file
 ImmichFrame/Settings.json
 ImmichFrame.WebApi/Config/Settings.json
+
+# QNAP NAS thumbnail cache
+.@__thumb/
+
+# Docker CLI / BuildKit local state
+.docker/


### PR DESCRIPTION
Adds two entries to `.gitignore`:

- `.@__thumb/` — QNAP NAS thumbnail cache directories (created by QNAP when the repo lives on a QNAP share)
- `.docker/` — Docker CLI / BuildKit local state (token seed, buildx node/refs) generated when `DOCKER_CONFIG` points at the project dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to keep local settings and temporary cache files out of version control.
  * Added coverage for additional NAS thumbnail cache and Docker/BuildKit state directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->