### PR TITLE
Configurable asset fetch batch size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -457,3 +457,9 @@ $RECYCLE.BIN/
 ## Ignore Settings file
 ImmichFrame/Settings.json
 ImmichFrame.WebApi/Config/Settings.json
+
+# QNAP NAS thumbnail cache
+.@__thumb/
+
+# Docker CLI / BuildKit local state
+.docker/

--- a/ImmichFrame.Core/Interfaces/IServerSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerSettings.cs
@@ -66,6 +66,7 @@
         public bool PlayAudio { get; }
         public string Layout { get; }
         public string Language { get; }
+        public int AssetBatchSize { get; }
 
         public void Validate();
     }

--- a/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
+++ b/ImmichFrame.Core/Logic/PooledImmichFrameLogic.cs
@@ -72,7 +72,10 @@ public class PooledImmichFrameLogic : IAccountImmichFrameLogic
 
     public async Task<IEnumerable<AssetResponseDto>> GetAssets()
     {
-        return await _pool.GetAssets(25);
+        // Immich's random search caps `size` at 1000 (and requires >= 1). Clamp here so any
+        // config source (V1 or V2) stays within bounds and can't fail the request.
+        var batchSize = Math.Clamp(_generalSettings.AssetBatchSize, 1, 1000);
+        return await _pool.GetAssets(batchSize);
     }
 
     public async Task<AssetResponseDto> GetAssetInfoById(Guid assetId) => await _immichApi.GetAssetInfoAsync(assetId, null, null);

--- a/ImmichFrame.WebApi.Tests/Resources/TestV1.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV1.json
@@ -9,6 +9,7 @@
     "ImageFill": true,
     "PlayAudio": true,
     "Layout": "Layout_TEST",
+    "AssetBatchSize": 7,
     "DownloadImages": true,
     "ShowMemories": true,
     "ShowFavorites": true,

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.json
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.json
@@ -35,7 +35,8 @@
     "ImagePan": true,
     "ImageFill": true,
     "PlayAudio": true,
-    "Layout": "Layout_TEST"
+    "Layout": "Layout_TEST",
+    "AssetBatchSize": 7
   },
   "Accounts": [
     {

--- a/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
+++ b/ImmichFrame.WebApi.Tests/Resources/TestV2.yml
@@ -35,6 +35,7 @@ General:
   ImageFill: true
   PlayAudio: true
   Layout: Layout_TEST
+  AssetBatchSize: 7
 Accounts:
 - ImmichServerUrl: Account1.ImmichServerUrl_TEST
   ApiKey: Account1.ApiKey_TEST

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -56,6 +56,7 @@ public class ServerSettingsV1 : IConfigSettable
     public bool ImageFill { get; set; } = false;
     public bool PlayAudio { get; set; } = false;
     public string Layout { get; set; } = "splitview";
+    public int AssetBatchSize { get; set; } = 25;
 }
 
 /// <summary>
@@ -135,6 +136,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
         public bool PlayAudio => _delegate.PlayAudio;
         public string Layout => _delegate.Layout;
         public string Language => _delegate.Language;
+        public int AssetBatchSize => _delegate.AssetBatchSize;
 
         public void Validate() { }
     }

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -72,6 +72,7 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string? WeatherLatLong { get; set; } = "40.7128,74.0060";
     public string? Webhook { get; set; }
     public string? AuthenticationSecret { get; set; }
+    public int AssetBatchSize { get; set; } = 25;
 
     public void Validate() { }
 }

--- a/docker/Settings.example.json
+++ b/docker/Settings.example.json
@@ -35,7 +35,8 @@
     "ImagePan": false,
     "ImageFill": false,
     "PlayAudio": false,
-    "Layout": "splitview"
+    "Layout": "splitview",
+    "AssetBatchSize": 25
   },
   "Accounts": [
     {

--- a/docker/Settings.example.yml
+++ b/docker/Settings.example.yml
@@ -34,6 +34,7 @@ General:
   ImageFill: false
   PlayAudio: false
   Layout: splitview
+  AssetBatchSize: 25
 Accounts:
   - ImmichServerUrl: REQUIRED
     # Exactly one of ApiKey or ApiKeyFile must be set.

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -104,6 +104,8 @@ General:
   PlayAudio: false  # boolean
   # Allow two portrait images to be displayed next to each other
   Layout: 'splitview'  # single | splitview
+  # Number of assets fetched per request from the server. Larger values show more distinct images before the random pool reshuffles, at the cost of a bigger initial fetch. Clamped to Immich's random-search range of 1-1000.
+  AssetBatchSize: 25  # int (1-1000)
 
 # multiple accounts permitted
 Accounts:


### PR DESCRIPTION
Assets are served from Immich via a stateless random search (`SearchRandomAsync`). Each batch returns 25 distinct assets, but there is no cross-batch "already shown" tracking — so once the frontend exhausts a batch and refetches, the next random draw can repeat images the viewer just saw. This means that currently, though I have hundreds of images in my album, I still get repetitions every 2 weeks or so.

### Change summary

Makes the number of assets fetched per request configurable via a new `AssetBatchSize` general setting (default 25, clamped to 1–1000), replacing the hardcoded 25 in `PooledImmichFrameLogic.GetAssets()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `General.AssetBatchSize` setting to control how many assets are fetched per request (default: 25), with matching updates to example Docker settings.
* **Bug Fixes**
  * Enforced safe batch-size limits by clamping the configured value to Immich’s supported range (1–1000).
* **Documentation**
  * Updated configuration reference and setup examples to include `General.AssetBatchSize`.
* **Tests**
  * Extended V1/V2 test configuration resources to cover the new setting.
* **Chores**
  * Updated version control ignore rules for additional generated/tool-local files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->