### PR TITLE
Fix memories endpoint 400 error due to missing timezone in datetime

### DIFF
--- a/ImmichFrame.Core.Tests/Logic/Pool/MemoryAssetsPoolTests.cs
+++ b/ImmichFrame.Core.Tests/Logic/Pool/MemoryAssetsPoolTests.cs
@@ -75,7 +75,7 @@ public class MemoryAssetsPoolTests
     public async Task LoadAssets_CallsSearchMemoriesAsync()
     {
         // Arrange
-        _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+        _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<MemoryResponseDto>());
 
         // Act
@@ -87,7 +87,7 @@ public class MemoryAssetsPoolTests
         await _memoryAssetsPool.GetAssets(1, CancellationToken.None); // This should trigger LoadAssets
 
         // Assert
-        _mockImmichApi.Verify(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()), Times.Once);
+        _mockImmichApi.Verify(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Test]
@@ -98,7 +98,7 @@ public class MemoryAssetsPoolTests
         var memories = CreateSampleImageMemories(1, 1, false, memoryYear); // Asset without ExifInfo
         var assetId = memories[0].Assets.First().Id;
 
-        _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+        _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(memories);
         _mockImmichApi.Setup(x => x.GetAssetInfoAsync(assetId, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new AssetResponseDto { Id = assetId, ExifInfo = new ExifResponseDto { DateTimeOriginal = new DateTime(memoryYear, 1, 1) }, People = new List<PersonResponseDto>() });
@@ -120,7 +120,7 @@ public class MemoryAssetsPoolTests
         var memories = CreateSampleImageMemories(1, 1, true, memoryYear); // Asset with ExifInfo
         var assetId = memories[0].Assets.First().Id;
 
-        _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+        _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(memories);
 
         // Act
@@ -149,7 +149,7 @@ public class MemoryAssetsPoolTests
             var memories = CreateSampleImageMemories(1, 1, true, tc.year);
             memories[0].Assets.First().ExifInfo.DateTimeOriginal = new DateTime(tc.year, 1, 1); // Ensure Exif has the year
 
-            _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+            _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(memories);
 
             _memoryAssetsPool = new MemoryAssetsPool(_mockImmichApi.Object, _mockAccountSettings.Object);
@@ -176,7 +176,7 @@ public class MemoryAssetsPoolTests
         var memories = CreateSampleImageMemories(imageMemoriesCount, assetsPerMemory, true, memoryYear); // 2 memories, 2 assets each
         memories.AddRange(CreateSampleVideoMemories(videoMemoriesCount, assetsPerMemory, true, memoryYear)); // 2 video memories, 2 assets each
 
-        _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+        _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(memories).Verifiable(Times.Once);
 
         // Act
@@ -210,7 +210,7 @@ public class MemoryAssetsPoolTests
         memories.AddRange(CreateSampleVideoMemories(videoMemoriesCount, assetsPerMemory, true, memoryYear)); // 2 video memories, 2 assets each
 
         _mockAccountSettings.Setup(x => x.ShowVideos).Returns(true);
-        _mockImmichApi.Setup(x => x.SearchMemoriesAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
+        _mockImmichApi.Setup(x => x.SearchMemoriesWithProperDateAsync(It.IsAny<DateTimeOffset>(), null, null, null, null, null, It.IsAny<CancellationToken>()))
             .ReturnsAsync(memories).Verifiable(Times.Once);
 
         // Act

--- a/ImmichFrame.Core/Api/ImmichApi.cs
+++ b/ImmichFrame.Core/Api/ImmichApi.cs
@@ -41,5 +41,85 @@
             response.Dispose();
             throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
         }
+
+        /// <summary>
+        /// Searches memories with a properly formatted ISO 8601 datetime (including timezone offset).
+        /// The NSwag-generated SearchMemoriesAsync uses the "s" format for DateTimeOffset, which omits
+        /// the timezone offset. Immich v3 requires full ISO 8601 with timezone, so this method manually
+        /// constructs the request with proper datetime formatting.
+        /// </summary>
+        public virtual async Task<ICollection<MemoryResponseDto>> SearchMemoriesWithProperDateAsync(
+            DateTimeOffset searchDate,
+            bool? isSaved = null,
+            bool? isTrashed = null,
+            MemorySearchOrder? order = null,
+            int? size = null,
+            MemoryType? type = null,
+            CancellationToken cancellationToken = default)
+        {
+            var urlBuilder = new System.Text.StringBuilder();
+            if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder.Append(_baseUrl);
+            urlBuilder.Append("memories?");
+
+            // Format with full ISO 8601 including timezone offset
+            urlBuilder.Append("for=");
+            urlBuilder.Append(Uri.EscapeDataString(searchDate.ToString("yyyy-MM-ddTHH:mm:sszzz")));
+
+            if (isSaved.HasValue)
+            {
+                urlBuilder.Append("&isSaved=");
+                urlBuilder.Append(Uri.EscapeDataString(isSaved.Value.ToString().ToLowerInvariant()));
+            }
+
+            if (isTrashed.HasValue)
+            {
+                urlBuilder.Append("&isTrashed=");
+                urlBuilder.Append(Uri.EscapeDataString(isTrashed.Value.ToString().ToLowerInvariant()));
+            }
+
+            if (order.HasValue)
+            {
+                urlBuilder.Append("&order=");
+                var orderStr = Newtonsoft.Json.JsonConvert.SerializeObject(order.Value, JsonSerializerSettings).Trim('"');
+                urlBuilder.Append(Uri.EscapeDataString(orderStr));
+            }
+
+            if (size.HasValue)
+            {
+                urlBuilder.Append("&size=");
+                urlBuilder.Append(Uri.EscapeDataString(size.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+            }
+
+            if (type.HasValue)
+            {
+                urlBuilder.Append("&type=");
+                var typeStr = Newtonsoft.Json.JsonConvert.SerializeObject(type.Value, JsonSerializerSettings).Trim('"');
+                urlBuilder.Append(Uri.EscapeDataString(typeStr));
+            }
+
+            using var request = new HttpRequestMessage(HttpMethod.Get, urlBuilder.ToString());
+            request.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+            var headers = new Dictionary<string, IEnumerable<string>>();
+            foreach (var item in response.Headers)
+                headers[item.Key] = item.Value;
+            if (response.Content?.Headers != null)
+                foreach (var item in response.Content.Headers)
+                    headers[item.Key] = item.Value;
+
+            var status = (int)response.StatusCode;
+            if (status == 200)
+            {
+                var json = response.Content == null ? string.Empty : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ICollection<MemoryResponseDto>>(json, JsonSerializerSettings);
+                return result ?? new List<MemoryResponseDto>();
+            }
+
+            var error = response.Content == null ? null : await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            response.Dispose();
+            throw new ApiException($"Unexpected status code ({status}).", status, error, headers, null);
+        }
     }
 }

--- a/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
+++ b/ImmichFrame.Core/Logic/Pool/MemoryAssetsPool.cs
@@ -10,7 +10,7 @@ public class MemoryAssetsPool(ImmichApi immichApi, IAccountSettings accountSetti
     protected override async Task<IEnumerable<AssetResponseDto>> LoadAssets(CancellationToken ct = default)
     {
         var searchDate = DateTimeOffset.Now;
-        var memories = await immichApi.SearchMemoriesAsync(searchDate, null, null, null, null, null, ct);
+        var memories = await immichApi.SearchMemoriesWithProperDateAsync(searchDate, cancellationToken: ct);
 
         var memoryAssets = new List<AssetResponseDto>();
         foreach (var memory in memories)


### PR DESCRIPTION
## Summary

- Fixes the memories endpoint returning `400: "Invalid input: expected ISO 8601 datetime string"` when used with Immich v3
- The NSwag-generated `SearchMemoriesAsync` serializes `DateTimeOffset` using the `"s"` (sortable) format, which produces datetimes like `2026-07-03T07:47:17` **without** timezone offset. Immich v3 now requires full ISO 8601 with timezone (e.g. `2026-07-03T07:47:17+00:00`)
- Adds `SearchMemoriesWithProperDateAsync` to the partial `ImmichApi` class (following the existing `PlayAssetVideoWithRangeAsync` pattern) that manually constructs the request URL with the `for` parameter formatted using `"yyyy-MM-ddTHH:mm:sszzz"`
- Updates `MemoryAssetsPool.LoadAssets` to call the new method instead of the generated one

Fixes #659

## Test plan

- [ ] Verify ImmichFrame connects to an Immich v3 instance and successfully loads memories without 400 errors
- [ ] Verify the `for` query parameter in the HTTP request includes timezone offset (e.g. `2026-07-03T07:47:17%2B00:00` or `2026-07-03T07:47:17Z`)
- [ ] Verify unit tests pass with the updated mock setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory searches to use the correct date/time format, helping return more accurate results across time zones.
  * Updated asset loading to fetch memories with the corrected search behavior, improving matching and enrichment for photos and videos.
  * Adjusted related checks to reflect the updated search flow, keeping memory-linked asset details consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->