### PR TITLE
Fix: Build warnings: svelte-kit sync prepare step, reactive shortcuts, and stale QR/link URL

### DIFF
--- a/immichFrame.Web/package.json
+++ b/immichFrame.Web/package.json
@@ -6,6 +6,7 @@
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",
+		"prepare": "svelte-kit sync",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",

--- a/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
+++ b/immichFrame.Web/src/lib/components/elements/imageoverlay/overlay-qr.svelte
@@ -6,7 +6,7 @@
 	}
 	let { id }: Props = $props();
 
-	let imageUrl = `https://my.immich.app/photos/${id}`;
+	let imageUrl = $derived(`https://my.immich.app/photos/${id}`);
 </script>
 
 <div

--- a/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
+++ b/immichFrame.Web/src/lib/components/elements/overlay-controls.svelte
@@ -48,7 +48,7 @@
 	}
 
 	// Define your shortcut list
-	const shortcutList = [
+	const shortcutList = $derived([
 		{
 			key: 'ArrowRight',
 			action: next
@@ -65,7 +65,7 @@
 			key: 'i',
 			action: showInfo
 		}
-	];
+	]);
 </script>
 
 <svelte:window use:shortcuts={shortcutList} />


### PR DESCRIPTION
## Summary

Fixes three build-time warnings seen in `immichFrame.Web`:

- **Missing `svelte-kit sync` prepare step**: `vite build` warns `Cannot find base config file "./.svelte-kit/tsconfig.json"` on a fresh checkout, since `.svelte-kit/` doesn't exist yet when Vite first reads `tsconfig.json`. Added the standard `"prepare": "svelte-kit sync"` script (the usual `create-svelte` scaffold entry) so `npm i` generates it automatically before `npm run build` ever runs.
- **`overlay-controls.svelte` reactivity warning**: `shortcutList` was built once as a plain `const` from the `next`/`back`/`pause`/`showInfo` props instead of reactively. Wrapped it in `$derived(...)`, matching the Svelte 5 compiler's own suggested fix.
- **`overlay-qr.svelte` stale QR/link (actual bug)**: `imageUrl` (used for both the QR code and the "Open in immich" link) was computed once from the `id` prop at component init. Since `image-overlay.svelte` renders `<OverlayQr id={asset.id} />` without forcing a remount, the QR code and link would silently keep pointing at whatever asset was current the *first* time the component was created, even as the slideshow advanced underneath. Wrapped `imageUrl` in `$derived(...)` so it now tracks the current asset.

No `Dockerfile`, `docker-compose.yml`, or config changes — this is a 3-line, 3-file fix.

## Test plan

- [x] `npm run check` (svelte-check) — 0 errors, 0 warnings
- [x] `npm run build` — confirmed all four warning strings (`Cannot find base config file`, `overlay-controls.svelte`, `overlay-qr.svelte`, `state_referenced_locally`) are gone from the output
- [x] Real `docker build` of this branch — same warnings confirmed absent from the full build log
- [x] Live browser regression check: opened the info overlay, let the slideshow advance (~23s), reopened it, and confirmed the "Open in immich" link's asset id changed to match the newly-displayed asset instead of staying frozen on the first one shown
- [x] Confirmed the keyboard shortcuts (`overlay-controls.svelte`) still work correctly (tested the `i` shortcut for opening the info overlay)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of QR code links and on-screen shortcut behavior so they stay up to date more consistently.
* **Chores**
  * Added a package setup step to better support project installation and preparation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->