### PR TITLE
feat(config): support file-backed weather API keys

### DIFF
--- a/ImmichFrame.WebApi.Tests/Helpers/Config/ConfigLoaderTest.cs
+++ b/ImmichFrame.WebApi.Tests/Helpers/Config/ConfigLoaderTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Collections;
 using System.Reflection;
 using ImmichFrame.Core.Interfaces;
@@ -68,6 +69,56 @@ public class ConfigLoaderTest
         VerifyConfig(config, true, false);
     }
 
+    [Test]
+    public void TestLoadConfigV2Json_WeatherApiKeyFile()
+    {
+        var configDir = Path.Combine(Path.GetTempPath(), $"immichframe-weather-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(configDir);
+        var keyFile = Path.Combine(configDir, "weather-api-key");
+
+        try
+        {
+            File.WriteAllText(keyFile, " weather-api-key \n");
+            var settings = new
+            {
+                General = new { WeatherApiKey = "", WeatherApiKeyFile = keyFile },
+                Accounts = new[]
+                {
+                    new { ImmichServerUrl = "https://immich.example", ApiKey = "account-api-key" }
+                }
+            };
+            File.WriteAllText(
+                Path.Combine(configDir, "Settings.json"),
+                JsonSerializer.Serialize(settings));
+
+            var config = _configLoader.LoadConfig(configDir);
+
+            Assert.That(config.GeneralSettings.WeatherApiKey, Is.EqualTo("weather-api-key"));
+        }
+        finally
+        {
+            Directory.Delete(configDir, recursive: true);
+        }
+    }
+
+    [Test]
+    public void TestLoadConfigV2Json_WeatherApiKeyFile_ConflictsWithInlineKey()
+    {
+        var settings = new GeneralSettings
+        {
+            WeatherApiKey = "inline-weather-api-key",
+            WeatherApiKeyFile = "weather-api-key-file"
+        };
+
+        var exception = Assert.Throws<Exception>(() => settings.Validate());
+
+        Assert.That(
+            exception!.Message,
+            Is.EqualTo("Cannot specify both WeatherApiKey and WeatherApiKeyFile. Please provide only one."));
+    }
+
+
+
     private void VerifyConfig(IServerSettings serverSettings, bool usePrefix, bool expectNullApiKeyFile)
     {
         VerifyProperties(serverSettings.GeneralSettings);
@@ -107,7 +158,8 @@ public class ConfigLoaderTest
             switch (type)
             {
                 case var t when t == typeof(string):
-                    if (prop.Name.Equals("ApiKeyFile") && expectNullApiKeyFile)
+                    if (prop.Name.Equals("ApiKeyFile") && expectNullApiKeyFile ||
+                        prop.Name.Equals("WeatherApiKeyFile") && value is null)
                     {
                         Assert.That(value, Is.EqualTo(null), prop.Name);
                     }

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -68,12 +68,24 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public List<string> Webcalendars { get; set; } = new();
     public int RefreshAlbumPeopleInterval { get; set; } = 12;
     public string? WeatherApiKey { get; set; } = string.Empty;
+    public string? WeatherApiKeyFile { get; set; } = null;
     public string? UnitSystem { get; set; } = "imperial";
     public string? WeatherLatLong { get; set; } = "40.7128,74.0060";
     public string? Webhook { get; set; }
     public string? AuthenticationSecret { get; set; }
 
-    public void Validate() { }
+    public void Validate()
+    {
+        if (!string.IsNullOrWhiteSpace(WeatherApiKeyFile))
+        {
+            if (!string.IsNullOrWhiteSpace(WeatherApiKey))
+            {
+                throw new Exception("Cannot specify both WeatherApiKey and WeatherApiKeyFile. Please provide only one.");
+            }
+
+            WeatherApiKey = File.ReadAllText(WeatherApiKeyFile).Trim();
+        }
+    }
 }
 
 public class ServerAccountSettings : IAccountSettings, IConfigSettable

--- a/docker/Settings.example.json
+++ b/docker/Settings.example.json
@@ -10,6 +10,7 @@
     "PhotoDateFormat": "MM/dd/yyyy",
     "ImageLocationFormat": "City,State,Country",
     "WeatherApiKey": "",
+    "WeatherApiKeyFile": null,
     "UnitSystem": "imperial",
     "WeatherLatLong": "40.730610,-73.935242",
     "Webhook": null,

--- a/docker/Settings.example.yml
+++ b/docker/Settings.example.yml
@@ -7,7 +7,9 @@ General:
   RefreshAlbumPeopleInterval: 12
   PhotoDateFormat: MM/dd/yyyy
   ImageLocationFormat: 'City,State,Country'
+  # Set either WeatherApiKey or WeatherApiKeyFile; leave both empty to disable weather.
   WeatherApiKey: ''
+  # WeatherApiKeyFile: '/path/to/weather-api.key'
   UnitSystem: imperial
   WeatherLatLong: '40.730610,-73.935242'
   Webhook: null

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -49,7 +49,9 @@ General:
   PhotoDateFormat: 'MM/dd/yyyy'  # string
   ImageLocationFormat: 'City,State,Country'
   # Get an API key from OpenWeatherMap: https://openweathermap.org/appid
+  # Set either WeatherApiKey or WeatherApiKeyFile; leave both empty to disable weather.
   WeatherApiKey: ''  # string
+  # WeatherApiKeyFile: '/path/to/weather-api.key'
   # Imperial or metric system (Fahrenheit or Celsius)
   UnitSystem: 'imperial'  # 'imperial' | 'metric'
   # Set the weather location with lat/lon.


### PR DESCRIPTION
Weather API keys are secrets and should not need to be hardcoded directly into `Settings.json` or `Settings.yml`, where they can be accidentally committed, copied, or exposed during configuration management.

This change adds `General.WeatherApiKeyFile`, allowing deployments to mount the key through a secret-management system and point ImmichFrame at the file instead. The key is read once during startup, trimmed, and passed through the existing weather configuration path.

Inline `WeatherApiKey` remains supported for compatibility. Configurations cannot specify both sources, and leaving both empty continues to disable weather.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weather API keys can now be loaded securely from a file.
  * Weather configuration supports either an inline API key or a file-based key.
* **Bug Fixes**
  * Added validation to prevent configuring both API key options simultaneously.
  * File-based keys are trimmed before use.
* **Documentation**
  * Updated JSON and YAML examples with the new weather API key file option.
  * Clarified how to enable or disable weather functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->