### PR TITLE
Send clientIdentifier with asset list and config requests

### DIFF
--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -74,12 +74,7 @@
 
 	let cursorVisible = $state(true);
 
-	const clientIdentifier = page.url.searchParams.get('client');
 	const authsecret = page.url.searchParams.get('authsecret');
-
-	if (clientIdentifier && clientIdentifier != $clientIdentifierStore) {
-		clientIdentifierStore.set(clientIdentifier);
-	}
 
 	if (authsecret && authsecret != $authSecretStore) {
 		authSecretStore.set(authsecret);

--- a/immichFrame.Web/src/lib/components/home-page/home-page.svelte
+++ b/immichFrame.Web/src/lib/components/home-page/home-page.svelte
@@ -137,7 +137,7 @@
 
 	async function loadAssets() {
 		try {
-			let assetRequest = await api.getAssets();
+			let assetRequest = await api.getAssets({ clientIdentifier: $clientIdentifierStore });
 
 			if (assetRequest.status != 200) {
 				if (assetRequest.status == 401) {

--- a/immichFrame.Web/src/routes/+page.ts
+++ b/immichFrame.Web/src/routes/+page.ts
@@ -1,9 +1,14 @@
 import * as api from '$lib/immichFrameApi';
 import { configStore } from '$lib/stores/config.store.js'
+import { clientIdentifierStore } from '$lib/stores/persist.store';
+import { get } from 'svelte/store';
+import type { PageLoad } from './$types';
 
-export const load = async () => {
+export const load: PageLoad = async ({ url }) => {
 
-  const configRequest = await api.getConfig({ clientIdentifier: "" });
+  const clientIdentifier = url.searchParams.get('client') ?? get(clientIdentifierStore);
+
+  const configRequest = await api.getConfig({ clientIdentifier });
 
   const config = configRequest.data;
 

--- a/immichFrame.Web/src/routes/+page.ts
+++ b/immichFrame.Web/src/routes/+page.ts
@@ -6,9 +6,12 @@ import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ url }) => {
 
-  const clientIdentifier = url.searchParams.get('client') ?? get(clientIdentifierStore);
+  const clientParam = url.searchParams.get('client');
+  if (clientParam) {
+    clientIdentifierStore.set(clientParam);
+  }
 
-  const configRequest = await api.getConfig({ clientIdentifier });
+  const configRequest = await api.getConfig({ clientIdentifier: get(clientIdentifierStore) });
 
   const config = configRequest.data;
 


### PR DESCRIPTION
The web client sends the clientIdentifier on asset detail, image, video, weather and calendar requests, but not on GET /api/Asset and GET /api/Config. Both endpoints already accept the parameter.

This passes the persisted identifier on both calls. The config load also reads the ?client= URL parameter directly, since it runs before the home page persists it, so the identifier is correct on the very first visit.

No server behavior changes, the parameter is currently only used for logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset loading by preserving the configured client identifier across page navigation.
  * Configuration and asset requests now correctly honor an optional client specified in the page URL.
  * Added a fallback to the previously persisted client identifier when no URL parameter is provided.
  * Ensured client selection remains consistent between initial configuration loading and subsequent asset requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->