### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can find a working demo [here](https://demo.immichframe.dev).
 
 ## 🌟 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=immichframe/immichframe&type=Date)](https://www.star-history.com/#immichframe/immichframe&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=immichframe/immichframe&type=Date)](https://star-history.dera.page/#immichframe/immichframe&Date)
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->


### PR DESCRIPTION
The star history chart in the README is currently broken and renders nothing because the upstream service it relied on has shut down. This PR points it at a working replacement so the chart displays correctly again. No other changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart and link to use the new Star History website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->