### PR TITLE
Add configurable calendar look-ahead window (CalendarDaysAhead)

### DIFF
--- a/ImmichFrame.Core/Helpers/CalendarExtensionMethods.cs
+++ b/ImmichFrame.Core/Helpers/CalendarExtensionMethods.cs
@@ -9,14 +9,14 @@ namespace ImmichFrame.WebApi.Helpers
         public static IAppointment ToAppointment(this Occurrence occurrence)
         {
             string summary = "";
-            string? description = null;
-            string? location = null;
+            string description = "";
+            string location = "";
 
             if (occurrence.Source is CalendarEvent calEvent)
             {
                 summary = calEvent.Summary;
-                description = calEvent.Description;
-                location = calEvent.Location;
+                description = calEvent.Description ?? "";
+                location = calEvent.Location ?? "";
             }
 
             return new Appointment
@@ -34,11 +34,11 @@ namespace ImmichFrame.WebApi.Helpers
             return new Appointment
             {
                 Summary = calEvent.Summary,
-                Description = calEvent.Description,
+                Description = calEvent.Description ?? "",
                 StartTime = calEvent.Start.AsSystemLocal,
                 Duration = calEvent.Duration,
                 EndTime = calEvent.End.AsSystemLocal,
-                Location = calEvent.Location
+                Location = calEvent.Location ?? ""
             };
         }
     }

--- a/ImmichFrame.Core/Helpers/CalendarExtensionMethods.cs
+++ b/ImmichFrame.Core/Helpers/CalendarExtensionMethods.cs
@@ -1,26 +1,32 @@
-﻿using Ical.Net.CalendarComponents;
+using Ical.Net.CalendarComponents;
 using Ical.Net.DataTypes;
 using ImmichFrame.Core.Interfaces;
 using ImmichFrame.Core.Models;
-
 namespace ImmichFrame.WebApi.Helpers
 {
     public static class CalendarExtensionMethods
     {
         public static IAppointment ToAppointment(this Occurrence occurrence)
         {
-            if (occurrence.Source.GetType() == typeof(CalendarEvent)) {
-                return ((CalendarEvent)occurrence.Source).ToAppointment();
+            string summary = "";
+            string? description = null;
+            string? location = null;
+
+            if (occurrence.Source is CalendarEvent calEvent)
+            {
+                summary = calEvent.Summary;
+                description = calEvent.Description;
+                location = calEvent.Location;
             }
 
             return new Appointment
             {
-                //Summary = occurrence.Period.Duration.Summary,
-                //Description = occurrence.Source.Description,
+                Summary = summary,
+                Description = description,
                 StartTime = occurrence.Period.StartTime.AsSystemLocal,
                 Duration = occurrence.Period.Duration,
                 EndTime = occurrence.Period.EndTime.AsSystemLocal,
-                Location = ""
+                Location = location
             };
         }
         public static IAppointment ToAppointment(this CalendarEvent calEvent)

--- a/ImmichFrame.Core/Interfaces/IServerBehaviorSettings.cs
+++ b/ImmichFrame.Core/Interfaces/IServerBehaviorSettings.cs
@@ -3,6 +3,7 @@ namespace ImmichFrame.Core.Interfaces
     public interface IServerBehaviorSettings
     {
         public List<string> Webcalendars { get; }
+        public int CalendarDaysAhead { get; }
         public int RefreshAlbumPeopleInterval { get; }
         public string? WeatherApiKey { get; }
         public string? WeatherLatLong { get; }

--- a/ImmichFrame.Core/Services/IcalCalendarService.cs
+++ b/ImmichFrame.Core/Services/IcalCalendarService.cs
@@ -47,11 +47,14 @@ public class IcalCalendarService : ICalendarService
 
             var icals = await GetCalendars(cals);
 
+            var endDate = DateTime.Today.AddDays(_serverSettings.CalendarDaysAhead + 1);
+
             foreach (var ical in icals)
             {
                 var calendar = Calendar.Load(ical);
-
-                appointments.AddRange(calendar.GetOccurrences(DateTime.Today, DateTime.Today.AddDays(1)).Select(x => x.ToAppointment()));
+                appointments.AddRange(calendar.GetOccurrences(DateTime.Today, endDate)
+                    .OrderBy(x => x.Period.StartTime.AsSystemLocal)
+                    .Select(x => x.ToAppointment()));
             }
 
             return appointments;

--- a/ImmichFrame.Core/Services/IcalCalendarService.cs
+++ b/ImmichFrame.Core/Services/IcalCalendarService.cs
@@ -47,17 +47,18 @@ public class IcalCalendarService : ICalendarService
 
             var icals = await GetCalendars(cals);
 
-            var endDate = DateTime.Today.AddDays(_serverSettings.CalendarDaysAhead + 1);
+            // Clamp to a sane range: never negative, and cap well below DateTime overflow.
+            var daysAhead = Math.Clamp(_serverSettings.CalendarDaysAhead, 0, 3650);
+            var endDate = DateTime.Today.AddDays(daysAhead + 1);
 
             foreach (var ical in icals)
             {
                 var calendar = Calendar.Load(ical);
                 appointments.AddRange(calendar.GetOccurrences(DateTime.Today, endDate)
-                    .OrderBy(x => x.Period.StartTime.AsSystemLocal)
                     .Select(x => x.ToAppointment()));
             }
 
-            return appointments;
+            return appointments.OrderBy(x => x.StartTime).ToList();
         });
     }
 

--- a/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
+++ b/ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs
@@ -24,6 +24,7 @@ public class ServerSettingsV1 : IConfigSettable
     public List<string> Tags { get; set; } = new List<string>();
     public int? Rating { get; set; }
     public List<string> Webcalendars { get; set; } = new List<string>();
+    public int CalendarDaysAhead { get; set; } = 0;
     public int RefreshAlbumPeopleInterval { get; set; } = 12;
     public string? WeatherApiKey { get; set; } = string.Empty;
     public string? UnitSystem { get; set; } = "imperial";
@@ -101,6 +102,7 @@ public class ServerSettingsV1Adapter(ServerSettingsV1 _delegate) : IServerSettin
     class GeneralSettingsV1Adapter(ServerSettingsV1 _delegate) : IGeneralSettings
     {
         public List<string> Webcalendars => _delegate.Webcalendars;
+        public int CalendarDaysAhead => _delegate.CalendarDaysAhead;
         public int RefreshAlbumPeopleInterval => _delegate.RefreshAlbumPeopleInterval;
         public string? WeatherApiKey => _delegate.WeatherApiKey;
         public string? WeatherLatLong => _delegate.WeatherLatLong;

--- a/ImmichFrame.WebApi/Models/ServerSettings.cs
+++ b/ImmichFrame.WebApi/Models/ServerSettings.cs
@@ -66,6 +66,7 @@ public class GeneralSettings : IGeneralSettings, IConfigSettable
     public string Layout { get; set; } = "splitview";
     public int RenewImagesDuration { get; set; } = 30;
     public List<string> Webcalendars { get; set; } = new();
+    public int CalendarDaysAhead { get; set; } = 0;
     public int RefreshAlbumPeopleInterval { get; set; } = 12;
     public string? WeatherApiKey { get; set; } = string.Empty;
     public string? UnitSystem { get; set; } = "imperial";

--- a/immichFrame.Web/src/lib/components/elements/appointments.svelte
+++ b/immichFrame.Web/src/lib/components/elements/appointments.svelte
@@ -4,43 +4,38 @@
 	import { format } from 'date-fns';
 	import { configStore } from '$lib/stores/config.store';
 	import { clientIdentifierStore } from '$lib/stores/persist.store';
-
 	api.init();
-
 	function formatDates(startTime: string, endTime: string) {
 		let startDate = new Date(startTime);
 		let endDate = new Date(endTime);
-		let sameDay = startDate.getDate() == endDate.getDate();
-
+		let sameDay = startDate.toDateString() == endDate.toDateString();
+		let today = new Date();
+		let isToday = startDate.toDateString() == today.toDateString();
 		let clockFormat = $configStore.clockFormat ?? 'HH:mm';
 		let clockDateFormat = $configStore.clockDateFormat ?? 'eee, MMM d';
 		let fullFormat = clockDateFormat + ' ' + clockFormat;
-
 		if (sameDay) {
-			return format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
+			if (isToday) {
+				return format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
+			}
+			return format(startDate, clockDateFormat) + ' ' + format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
 		}
-
 		return format(startDate, fullFormat) + ' - ' + format(endDate, fullFormat);
 	}
-
 	let appointments: api.IAppointment[] = $state() as api.IAppointment[];
-
 	onMount(() => {
 		GetAppointments();
 		const appointmentInterval = setInterval(() => GetAppointments(), 10 * 60 * 1000); //every 10 minutes
-
 		return () => {
 			clearInterval(appointmentInterval);
 		};
 	});
-
 	async function GetAppointments() {
 		let appointmentRequest = await api.getAppointments({
 			clientIdentifier: $clientIdentifierStore
 		});
 		if (appointmentRequest.status == 200) {
 			appointments = appointmentRequest.data;
-
 			appointments = appointmentRequest.data.sort((a, b) => {
 				return new Date(a.startTime ?? '').getTime() - new Date(b.startTime ?? '').getTime();
 			});


### PR DESCRIPTION
Adds a new optional setting, CalendarDaysAhead (default 0, fully backward-compatible), that widens the calendar widget's query window from "today only" to "today + N days" — useful for photo frames where a full week's view is more useful than a single day.

Also fixes a bug where recurring calendar events always displayed their original/master start date instead of the actual date of the specific occurrence returned by GetOccurrences() — this was largely invisible before since the window was always exactly one day, but breaks the whole feature once the window is widened.

Full breakdown of the 6 files changed, with diffs and testing notes, is below.

AI disclaimer - I am not a coder at all, this was all done with Claude Sonnet5 and only the slightest idea of what I was doing. 
[calendar-lookahead-pr.md](https://github.com/user-attachments/files/31113429/calendar-lookahead-pr.md)


# Add configurable calendar look-ahead window (`CalendarDaysAhead`)

Closes #627

## Problem

The calendar widget only ever fetches and displays **today's** events
(`GetOccurrences(DateTime.Today, DateTime.Today.AddDays(1))`). For a
passive display like a photo frame, that means you only see what's
happening today and miss anything coming up later in the week.

While implementing this I also found and fixed a pre-existing bug: for
recurring events, every occurrence was displayed using the **master
event's original start date** instead of the date of the specific
occurrence found by `GetOccurrences()`. This wasn't very visible before
because the window was always exactly "today," but it becomes obvious
(and breaks the whole feature) once the window is widened to a week.

## Solution

Adds a new setting, `CalendarDaysAhead` (default `0`, fully
backward-compatible), that widens the calendar query window from
"today only" to "today + N days." Also fixes the recurring-event date
mapping bug, and updates the frontend to show a date alongside the
time for any event that isn't today.

## Files changed

### 1. `ImmichFrame.Core/Interfaces/IServerBehaviorSettings.cs`
Add the new setting to the interface.

```diff
 public interface IServerBehaviorSettings
 {
     public List<string> Webcalendars { get; }
+    public int CalendarDaysAhead { get; }
     public int RefreshAlbumPeopleInterval { get; }
     public string? WeatherApiKey { get; }
     public string? WeatherLatLong { get; }
     public string? UnitSystem { get; }
     public string? Webhook { get; }
     public string? AuthenticationSecret { get; }
 }
```

### 2. `ImmichFrame.WebApi/Models/ServerSettings.cs`
Add the concrete property (current-format `Settings.json`/YAML/env path),
default `0` so existing configs are unaffected.

```diff
 public List<string> Webcalendars { get; set; } = new();
+public int CalendarDaysAhead { get; set; } = 0;
 public int RefreshAlbumPeopleInterval { get; set; } = 12;
```

### 3. `ImmichFrame.WebApi/Helpers/Config/ServerSettingsV1.cs`
Add the same property to the **legacy/flat V1 settings class** (this is
the path used when configuring purely via environment variables with no
`Settings.json`/YAML present), and forward it through the V1 adapter.

```diff
 public class ServerSettingsV1 : IConfigSettable
 {
     ...
     public List<string> Webcalendars { get; set; } = new List<string>();
+    public int CalendarDaysAhead { get; set; } = 0;
     public int RefreshAlbumPeopleInterval { get; set; } = 12;
     ...
 }
```

```diff
 class GeneralSettingsV1Adapter(ServerSettingsV1 _delegate) : IGeneralSettings
 {
     public List<string> Webcalendars => _delegate.Webcalendars;
+    public int CalendarDaysAhead => _delegate.CalendarDaysAhead;
     public int RefreshAlbumPeopleInterval => _delegate.RefreshAlbumPeopleInterval;
     ...
 }
```

### 4. `ImmichFrame.Core/Services/IcalCalendarService.cs`
Use the new setting to widen the query window, and sort results
chronologically (previously trivial since there was only ever one day's
worth of data to return).

```diff
 var icals = await GetCalendars(cals);

+var endDate = DateTime.Today.AddDays(_serverSettings.CalendarDaysAhead + 1);
+
 foreach (var ical in icals)
 {
     var calendar = Calendar.Load(ical);
-
-    appointments.AddRange(calendar.GetOccurrences(DateTime.Today, DateTime.Today.AddDays(1)).Select(x => x.ToAppointment()));
+    appointments.AddRange(calendar.GetOccurrences(DateTime.Today, endDate)
+        .OrderBy(x => x.Period.StartTime.AsSystemLocal)
+        .Select(x => x.ToAppointment()));
 }
```

### 5. `ImmichFrame.Core/Helpers/CalendarExtensionMethods.cs`
**Bug fix.** The `Occurrence` overload of `ToAppointment()` was
delegating to the `CalendarEvent` overload whenever the occurrence's
source was a `CalendarEvent`, which uses `calEvent.Start`/`calEvent.End`
— the **master event's original date**, not the specific occurrence's
actual date. For a weekly recurring event, every returned occurrence
therefore displayed the same (wrong) date, regardless of which
occurrence was actually found by `GetOccurrences()`.

The fix keeps the correct per-occurrence timing
(`occurrence.Period.StartTime`/`EndTime`) while still pulling
`Summary`/`Description`/`Location` from the source event.

```diff
 public static IAppointment ToAppointment(this Occurrence occurrence)
 {
-    if (occurrence.Source.GetType() == typeof(CalendarEvent)) {
-        return ((CalendarEvent)occurrence.Source).ToAppointment();
-    }
+    string summary = "";
+    string? description = null;
+    string? location = null;
+
+    if (occurrence.Source is CalendarEvent calEvent)
+    {
+        summary = calEvent.Summary;
+        description = calEvent.Description;
+        location = calEvent.Location;
+    }
+
     return new Appointment
     {
-        //Summary = occurrence.Period.Duration.Summary,
-        //Description = occurrence.Source.Description,
+        Summary = summary,
+        Description = description,
         StartTime = occurrence.Period.StartTime.AsSystemLocal,
         Duration = occurrence.Period.Duration,
         EndTime = occurrence.Period.EndTime.AsSystemLocal,
-        Location = ""
+        Location = location
     };
 }
```

### 6. `immichFrame.Web/src/lib/components/elements/appointments.svelte`
The date-formatting helper only ever checked whether an event's own
start/end fell on the *same day as each other* (i.e. whether it spans
midnight) to decide if a date should be shown — a reasonable
simplification when every event was always "today," but it means that
once the window spans a week, non-today events still only show a time,
with no way to tell which day they're on. Now it also checks whether
the event is today, and shows the date for anything that isn't.

```diff
 function formatDates(startTime: string, endTime: string) {
     let startDate = new Date(startTime);
     let endDate = new Date(endTime);
-    let sameDay = startDate.getDate() == endDate.getDate();
+    let sameDay = startDate.toDateString() == endDate.toDateString();
+    let today = new Date();
+    let isToday = startDate.toDateString() == today.toDateString();
     let clockFormat = $configStore.clockFormat ?? 'HH:mm';
     let clockDateFormat = $configStore.clockDateFormat ?? 'eee, MMM d';
     let fullFormat = clockDateFormat + ' ' + clockFormat;
     if (sameDay) {
-        return format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
+        if (isToday) {
+            return format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
+        }
+        return format(startDate, clockDateFormat) + ' ' + format(startDate, clockFormat) + ' - ' + format(endDate, clockFormat);
     }
     return format(startDate, fullFormat) + ' - ' + format(endDate, fullFormat);
 }
```

## Configuration

New optional setting, works the same way as existing settings across
all three config methods (`Settings.json`, `Settings.yml`, environment
variables):

| Key | Type | Default | Description |
|---|---|---|---|
| `CalendarDaysAhead` | int | `0` | Number of additional days beyond today to fetch calendar events for. `0` preserves existing today-only behavior. |

Example env var: `CalendarDaysAhead=7` shows today plus the next 7 days.

## Testing performed

- Verified against a real Proton Calendar `.ics` feed containing
  single-occurrence and weekly-recurring (`RRULE:FREQ=WEEKLY`) events,
  including one with an `EXDATE` exception.
- Confirmed `CalendarDaysAhead=0` reproduces exact previous behavior
  (today only).
- Confirmed `CalendarDaysAhead=7` correctly returns events across the
  full window, with recurring events landing on their correct
  occurrence dates (previously they all incorrectly showed the
  recurrence's original start date).
- Verified via both `Settings.json`-style config and pure
  environment-variable config (the legacy `ServerSettingsV1` path),
  since these bind settings differently.
- Confirmed frontend correctly shows time-only for today's events and
  date+time for events on other days.

## Known limitations / open questions for reviewers

- Multi-day/all-day events are labeled with the full `fullFormat`
  (date + time) on both ends; happy to adjust formatting if maintainers
  have a preferred convention for all-day events specifically.
- Didn't add a UI/settings-page toggle for this — it's env/config-file
  only for now, matching how `Webcalendars` itself works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to control how many days ahead calendar appointments are retrieved, supporting a range of 0–3650 days.
  - Calendar appointments are now ordered by their local start time.

- **Bug Fixes**
  - Calendar events now consistently preserve their summary, description, location, and scheduled period.
  - Improved appointment date and time formatting: today’s events show times only, while future and multi-day events display appropriate date details.
  - Calendar event details now remain consistent when optional information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->