### PR TITLE
use asset timezone

### DIFF
--- a/immichFrame.Web/package-lock.json
+++ b/immichFrame.Web/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"devDependencies": {
 				"@castlenine/svelte-qrcode": "^2.3.0",
+				"@date-fns/tz": "^1.5.0",
 				"@mdi/js": "^7.4.47",
 				"@sveltejs/adapter-static": "^3.0.5",
 				"@sveltejs/kit": "^2.46.4",
@@ -147,6 +148,13 @@
 			"peerDependencies": {
 				"svelte": ">=3.54.0"
 			}
+		},
+		"node_modules/@date-fns/tz": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+			"integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.28.1",

--- a/immichFrame.Web/package.json
+++ b/immichFrame.Web/package.json
@@ -15,6 +15,7 @@
 	},
 	"devDependencies": {
 		"@castlenine/svelte-qrcode": "^2.3.0",
+		"@date-fns/tz": "^1.5.0",
 		"@mdi/js": "^7.4.47",
 		"@sveltejs/adapter-static": "^3.0.5",
 		"@sveltejs/kit": "^2.46.4",

--- a/immichFrame.Web/src/lib/components/elements/asset-info.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset-info.svelte
@@ -47,14 +47,25 @@
 
 		return Array.from(locationParts).join(', ');
 	}
+	function isValidTimeZone(timeZone: string) {
+		try {
+			Intl.DateTimeFormat(undefined, { timeZone });
+			return true;
+		} catch {
+			return false;
+		}
+	}
 	function parseExifTimeZone(exifTz?: string | null) {
+		if (exifTz && isValidTimeZone(exifTz)) return exifTz;
+
 		const match = exifTz?.match(/UTC([+-])(\d{1,2})(?::(\d{2}))?/i);
-		if (!match) return undefined;
+		if (match) {
+			const [, sign, hours, minutes = '00'] = match;
+			const paddedHours = hours.padStart(2, '0');
+			return `${sign}${paddedHours}:${minutes}`;
+		}
 
-		const [, sign, hours, minutes = '00'] = match;
-		const paddedHours = hours.padStart(2, '0');
-
-		return `${sign}${paddedHours}:${minutes}`;
+		return 'UTC';
 	}
 	let assetDate = $derived(asset.exifInfo?.dateTimeOriginal);
 	let assetTimeZone = $derived(asset.exifInfo?.timeZone);

--- a/immichFrame.Web/src/lib/components/elements/asset-info.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset-info.svelte
@@ -56,16 +56,14 @@
 		}
 	}
 	function parseExifTimeZone(exifTz?: string | null) {
-		if (exifTz && isValidTimeZone(exifTz)) return exifTz;
-
-		const match = exifTz?.match(/UTC([+-])(\d{1,2})(?::(\d{2}))?/i);
+		const match = exifTz?.match(/^UTC([+-])(\d{1,2})(?::(\d{2}))?$/i);
 		if (match) {
 			const [, sign, hours, minutes = '00'] = match;
 			const paddedHours = hours.padStart(2, '0');
-			return `${sign}${paddedHours}:${minutes}`;
+			exifTz = `${sign}${paddedHours}:${minutes}`;
 		}
-
-		return 'UTC';
+		
+		return exifTz && isValidTimeZone(exifTz) ? exifTz : 'UTC';
 	}
 	let assetDate = $derived(asset.exifInfo?.dateTimeOriginal);
 	let assetTimeZone = $derived(asset.exifInfo?.timeZone);

--- a/immichFrame.Web/src/lib/components/elements/asset-info.svelte
+++ b/immichFrame.Web/src/lib/components/elements/asset-info.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type AlbumResponseDto, type AssetResponseDto } from '$lib/immichFrameApi';
 	import { format } from 'date-fns';
+	import { TZDate } from '@date-fns/tz';
 	import * as locale from 'date-fns/locale';
 	import { configStore } from '$lib/stores/config.store';
 	import Icon from './icon.svelte';
@@ -46,9 +47,19 @@
 
 		return Array.from(locationParts).join(', ');
 	}
+	function parseExifTimeZone(exifTz?: string | null) {
+		const match = exifTz?.match(/UTC([+-])(\d{1,2})(?::(\d{2}))?/i);
+		if (!match) return undefined;
+
+		const [, sign, hours, minutes = '00'] = match;
+		const paddedHours = hours.padStart(2, '0');
+
+		return `${sign}${paddedHours}:${minutes}`;
+	}
 	let assetDate = $derived(asset.exifInfo?.dateTimeOriginal);
+	let assetTimeZone = $derived(asset.exifInfo?.timeZone);
 	let desc = $derived(asset.exifInfo?.description ?? '');
-	let time = $derived(assetDate ? new Date(assetDate) : null);
+	let time = $derived(assetDate ? new TZDate(assetDate, parseExifTimeZone(assetTimeZone)) : null);
 	const selectedLocale = $configStore.language;
 
 	const localeToUse =


### PR DESCRIPTION
Display assets with their own timezone instead of the local timezone
Resolves #696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset date and time display by correctly applying timezone information from photo metadata.
  * Prevented timestamps from being interpreted using the device’s local timezone when EXIF data includes a UTC offset.
  * Invalid or missing timezone information now safely defaults to UTC.
  * Standardized timezone offset handling for more consistent timestamp accuracy across assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->