### PR TITLE
Fix: Docker build fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /app
 COPY --chown=node:node ./immichFrame.Web/package*.json ./
 
 # Cache npm dependencies
-RUN npm i
+RUN npm ci
 COPY --chown=node:node ./immichFrame.Web ./
 RUN npm run build && npm prune --omit=dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,13 @@ ENV APP_VERSION=$VERSION
 COPY --from=publish-api /app ./
 COPY --from=build-node /app/build ./wwwroot
 
-# Set non-privileged user
+# The settings database lives here, so it has to be writable by the runtime user.
+# A fresh named volume inherits this ownership; a bind mount keeps the host's, which
+# is why the host directory has to be chown'ed to the same uid.
 ARG APP_UID=1000
+RUN mkdir -p /app/Config && chown -R $APP_UID:0 /app/Config && chmod -R g+w /app/Config
+
+# Set non-privileged user
 USER $APP_UID
 
 ENTRYPOINT ["dotnet", "ImmichFrame.WebApi.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV APP_VERSION=$VERSION
 RUN dotnet publish --runtime linux-${TARGETARCH} --self-contained false -p:AssemblyVersion=$VERSION -o /app
 
 # Stage 3: Build frontend with Node.js
-FROM node:22-alpine AS build-node
+FROM node:22-bookworm-slim AS build-node
 
 USER node
 WORKDIR /app
@@ -33,7 +33,7 @@ COPY --chown=node:node ./immichFrame.Web/package*.json ./
 # Cache npm dependencies
 RUN npm ci
 COPY --chown=node:node ./immichFrame.Web ./
-RUN npm rebuild && npm run build && npm prune --omit=dev
+RUN npm run build && npm prune --omit=dev
 
 # Stage 4: Final production stage
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS final

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY --chown=node:node ./immichFrame.Web/package*.json ./
 # Cache npm dependencies
 RUN npm ci
 COPY --chown=node:node ./immichFrame.Web ./
-RUN npm run build && npm prune --omit=dev
+RUN npm rebuild && npm run build && npm prune --omit=dev
 
 # Stage 4: Final production stage
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy AS final

--- a/ImmichFrame.WebApi/Services/SettingsService.cs
+++ b/ImmichFrame.WebApi/Services/SettingsService.cs
@@ -4,6 +4,7 @@ using ImmichFrame.Core.Interfaces;
 using ImmichFrame.WebApi.Database;
 using ImmichFrame.WebApi.Helpers.Config;
 using ImmichFrame.WebApi.Models;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace ImmichFrame.WebApi.Services;
@@ -34,6 +35,9 @@ public class SettingsService : ISettingsProvider
     private readonly SettingsServiceOptions _options;
     private readonly SemaphoreSlim _updateLock = new(1, 1);
 
+    /// <summary>SQLITE_CANTOPEN: the database file could not be opened, almost always a permission problem.</summary>
+    private const int SQLITE_CANTOPEN = 14;
+
     private volatile IServerSettings _current = EmptySettings();
     // The raw (pre-Validate) form: ApiKeyFile stays unresolved so it round-trips to the admin UI and DB
     private ServerSettings _raw = EmptySettings();
@@ -60,9 +64,24 @@ public class SettingsService : ISettingsProvider
 
     public async Task InitializeAsync()
     {
-        Directory.CreateDirectory(_options.ConfigPath);
+        try
+        {
+            Directory.CreateDirectory(_options.ConfigPath);
+        }
+        catch (Exception ex) when (ex is UnauthorizedAccessException or IOException)
+        {
+            throw ConfigPathNotWritable(ex);
+        }
+
         await using var db = await _dbFactory.CreateDbContextAsync();
-        await db.Database.MigrateAsync();
+        try
+        {
+            await db.Database.MigrateAsync();
+        }
+        catch (SqliteException ex) when (ex.SqliteErrorCode == SQLITE_CANTOPEN)
+        {
+            throw ConfigPathNotWritable(ex);
+        }
 
         var row = await db.SettingsDocuments.FindAsync(1);
         if (row != null)
@@ -76,6 +95,16 @@ public class SettingsService : ISettingsProvider
         }
 
         await ImportOrBootstrap(db);
+    }
+
+    private ImmichFrameException ConfigPathNotWritable(Exception inner)
+    {
+        var message = $"Cannot open the settings database in '{_options.ConfigPath}'. " +
+            "The config directory has to exist and be writable by the user ImmichFrame runs as " +
+            "(uid 1000 in the official Docker image). For a bind mount, fix it on the host with " +
+            "'chown -R 1000:1000 /path/to/config'; a read-only mount does not work.";
+        _logger.LogError(inner, "{message}", message);
+        return new ImmichFrameException(message, inner);
     }
 
     private async Task ImportOrBootstrap(SettingsDbContext db)

--- a/docs/docs/getting-started/admin-ui.md
+++ b/docs/docs/getting-started/admin-ui.md
@@ -51,6 +51,9 @@ the config directory (`/app/Config` in Docker). This makes the config directory 
 place to persist:
 
 - Mount `/app/Config` as a **writable** volume, otherwise saving settings fails.
+  The container runs as uid `1000`, so a bind-mounted host directory has to belong to it:
+  `chown -R 1000:1000 /path/to/config`. If it does not, the container stops at startup with
+  `Cannot open the settings database in '/app/Config'`.
 - **The database is the source of truth.** On the very first start, an existing
   `Settings.json`, `Settings.yml` or `Settings.yaml` is imported into the database once.
   After that, changes to that file are ignored (a log line reminds you of this at startup).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved startup handling when the configuration directory or settings database cannot be accessed.
  - Added a clear error message with guidance for correcting configuration-directory permissions.

- **Documentation**
  - Clarified that Docker-mounted configuration directories must be owned by UID 1000.
  - Documented the startup error displayed when the settings database cannot be opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->